### PR TITLE
MinPlatformPkg: Add TPM platform hierarchy disable support

### DIFF
--- a/MinPlatformPkg/Include/Library/TpmPlatformHierarchyLib.h
+++ b/MinPlatformPkg/Include/Library/TpmPlatformHierarchyLib.h
@@ -6,15 +6,13 @@
     Policy (platformPolicy) can be defined through this function.
 
 Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #ifndef _TPM_PLATFORM_HIERARCHY_LIB_H_
 #define _TPM_PLATFORM_HIERARCHY_LIB_H_
-
-#include <PiDxe.h>
-#include <Uefi.h>
 
 /**
    This service will perform the TPM Platform Hierarchy configuration at the SmmReadyToLock event.

--- a/MinPlatformPkg/MinPlatformPkg.dec
+++ b/MinPlatformPkg/MinPlatformPkg.dec
@@ -231,6 +231,7 @@
   gMinPlatformPkgTokenSpaceGuid.PcdPciNoExtendedConfigSpace    |FALSE|BOOLEAN|0x4001004C
   gMinPlatformPkgTokenSpaceGuid.PcdPciResourceAssigned         |FALSE|BOOLEAN|0x4001004D
   gMinPlatformPkgTokenSpaceGuid.PcdPciSegmentCount             |0x1    |UINT8|0x4001004E
+  gMinPlatformPkgTokenSpaceGuid.PcdRandomizePlatformHierarchy  |TRUE |BOOLEAN|0x4001004F
 
   gMinPlatformPkgTokenSpaceGuid.PcdAcpiPm1AEventBlockAddress|0x1800|UINT16|0x00010035
   gMinPlatformPkgTokenSpaceGuid.PcdAcpiPm1BEventBlockAddress|0x0000|UINT16|0x00010036

--- a/MinPlatformPkg/MinPlatformPkg.dsc
+++ b/MinPlatformPkg/MinPlatformPkg.dsc
@@ -98,6 +98,7 @@
   TestPointCheckLib|MinPlatformPkg/Test/Library/TestPointCheckLib/PeiTestPointCheckLib.inf
   TestPointLib|MinPlatformPkg/Test/Library/TestPointLib/PeiTestPointLib.inf
   SetCacheMtrrLib|MinPlatformPkg/Library/SetCacheMtrrLib/SetCacheMtrrLibNull.inf
+  TpmPlatformHierarchyLib|MinPlatformPkg/Tcg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
 
 [LibraryClasses.common.DXE_DRIVER]
   #

--- a/MinPlatformPkg/MinPlatformPkg.dsc
+++ b/MinPlatformPkg/MinPlatformPkg.dsc
@@ -106,7 +106,7 @@
   FspWrapperPlatformLib|MinPlatformPkg/FspWrapper/Library/DxeFspWrapperPlatformLib/DxeFspWrapperPlatformLib.inf
   TestPointCheckLib|MinPlatformPkg/Test/Library/TestPointCheckLib/DxeTestPointCheckLib.inf
   TestPointLib|MinPlatformPkg/Test/Library/TestPointLib/DxeTestPointLib.inf
-  TpmPlatformHierarchyLib|MinPlatformPkg/Tcg/Library/TpmPlatformHierarchyLib/TpmPlatformHierarchyLib.inf
+  TpmPlatformHierarchyLib|MinPlatformPkg/Tcg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
 
 [LibraryClasses.common.DXE_SMM_DRIVER]
   SpiFlashCommonLib|MinPlatformPkg/Flash/Library/SpiFlashCommonLibNull/SpiFlashCommonLibNull.inf
@@ -211,7 +211,7 @@
   MinPlatformPkg/Test/TestPointStubDxe/TestPointStubDxe.inf
   MinPlatformPkg/Test/TestPointDumpApp/TestPointDumpApp.inf
 
-  MinPlatformPkg/Tcg/Library/TpmPlatformHierarchyLib/TpmPlatformHierarchyLib.inf
+  MinPlatformPkg/Tcg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
 !if gMinPlatformPkgTokenSpaceGuid.PcdTpm2Enable == TRUE
   MinPlatformPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
   MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf

--- a/MinPlatformPkg/MinPlatformPkg.dsc
+++ b/MinPlatformPkg/MinPlatformPkg.dsc
@@ -150,7 +150,6 @@
   MinPlatformPkg/Pci/Library/PciSegmentInfoLibSimple/PciSegmentInfoLibSimple.inf
   MinPlatformPkg/PlatformInit/Library/PeiReportFvLib/PeiReportFvLib.inf
   MinPlatformPkg/PlatformInit/Library/ReportCpuHobLib/ReportCpuHobLib.inf
-  MinPlatformPkg/Tcg/Library/TpmPlatformHierarchyLib/TpmPlatformHierarchyLib.inf
   MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
   MinPlatformPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
   MinPlatformPkg/Test/Library/TestPointCheckLib/SmmTestPointCheckLib.inf
@@ -212,6 +211,7 @@
   MinPlatformPkg/Test/TestPointStubDxe/TestPointStubDxe.inf
   MinPlatformPkg/Test/TestPointDumpApp/TestPointDumpApp.inf
 
+  MinPlatformPkg/Tcg/Library/TpmPlatformHierarchyLib/TpmPlatformHierarchyLib.inf
 !if gMinPlatformPkgTokenSpaceGuid.PcdTpm2Enable == TRUE
   MinPlatformPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
   MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf

--- a/MinPlatformPkg/Tcg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.c
+++ b/MinPlatformPkg/Tcg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.c
@@ -12,16 +12,13 @@
     https://trustedcomputinggroup.org/resource/tcg-tpm-v2-0-provisioning-guidance/
 **/
 
-#include <PiDxe.h>
+#include <Uefi.h>
 
-#include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/UefiBootServicesTableLib.h>
+#include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/Tpm2CommandLib.h>
 #include <Library/RngLib.h>
-#include <Library/UefiLib.h>
-#include <Protocol/DxeSmmReadyToLock.h>
+#include <Library/Tpm2CommandLib.h>
 
 //
 // The authorization value may be no larger than the digest produced by the hash

--- a/MinPlatformPkg/Tcg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
+++ b/MinPlatformPkg/Tcg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
@@ -7,6 +7,7 @@
 #   Policy (platformPolicy) can be defined through this function.
 #
 # Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -14,23 +15,19 @@
 
 [Defines]
   INF_VERSION                    = 0x00010005
-  BASE_NAME                      = TpmPlatformHierarchyLib
+  BASE_NAME                      = PeiDxeTpmPlatformHierarchyLib
   FILE_GUID                      = 7794F92C-4E8E-4E57-9E4A-49A0764C7D73
-  MODULE_TYPE                    = DXE_DRIVER
+  MODULE_TYPE                    = PEIM
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = TpmPlatformHierarchyLib
+  LIBRARY_CLASS                  = TpmPlatformHierarchyLib|PEIM DXE_DRIVER
 
 [LibraryClasses]
-  MemoryAllocationLib
   BaseLib
-  UefiBootServicesTableLib
-  UefiDriverEntryPoint
   BaseMemoryLib
   DebugLib
-  Tpm2CommandLib
-  Tpm2DeviceLib
+  MemoryAllocationLib
   RngLib
-  UefiLib
+  Tpm2CommandLib
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -39,7 +36,4 @@
   CryptoPkg/CryptoPkg.dec
 
 [Sources]
-  TpmPlatformHierarchyLib.c
-
-[Depex]
-  gEfiTcg2ProtocolGuid
+  PeiDxeTpmPlatformHierarchyLib.c

--- a/MinPlatformPkg/Tcg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
+++ b/MinPlatformPkg/Tcg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
@@ -26,14 +26,20 @@
   BaseMemoryLib
   DebugLib
   MemoryAllocationLib
+  PcdLib
   RngLib
   Tpm2CommandLib
+  Tpm2DeviceLib
 
 [Packages]
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   SecurityPkg/SecurityPkg.dec
   CryptoPkg/CryptoPkg.dec
+  MinPlatformPkg/MinPlatformPkg.dec
 
 [Sources]
   PeiDxeTpmPlatformHierarchyLib.c
+
+[Pcd]
+  gMinPlatformPkgTokenSpaceGuid.PcdRandomizePlatformHierarchy

--- a/MinPlatformPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
+++ b/MinPlatformPkg/Tcg/Tcg2PlatformPei/Tcg2PlatformPei.inf
@@ -29,11 +29,13 @@
   DebugLib
   Tpm2DeviceLib
   Tpm2CommandLib
+  TpmPlatformHierarchyLib
   RngLib
 
 [Packages]
   MdePkg/MdePkg.dec
   SecurityPkg/SecurityPkg.dec
+  MinPlatformPkg/MinPlatformPkg.dec
 
 [Sources]
   Tcg2PlatformPei.c


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3411

This patch series adds support in TpmPlatformHierarchyLib to either
randomize the platform auth (current behavior) or disable the
platform auth (new behavior) based on a new PCD introduced to
MinPlatformPkg: PcdRandomizePlatformHierarchy.

Some platforms that would like to adopt MinPlatformPkg prefer to
disable the platform hierarchy as opposed to the randomization
approach.

Minor changes are included to eliminate code duplication in impacted
code.

V2 changes:
1. Update code that randomizes the platform auth in Tcg2PlatformPei
   to use the TpmPlatformHierarchyLib interface for platform
   hierarchy configuration.
2. Remove pre-existing redundant code in Tcg2PlatformPei.
3. Add a PCD to allow the platform integrator to choose how to
   configure the TPM platform hierarchy.
   
Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Jiewen Yao <jiewen.yao@intel.com>
Cc: Jeremiah Cox <jerecox@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>