### PR TITLE
MinPlatformPkg/SpiFvbService: Allow dynamic flash info PCDs

### DIFF
--- a/MinPlatformPkg/Flash/SpiFvbService/FvbInfo.c
+++ b/MinPlatformPkg/Flash/SpiFvbService/FvbInfo.c
@@ -3,6 +3,7 @@
   These data is intent to decouple FVB driver with FV header.
 
 Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -11,52 +12,102 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define FIRMWARE_BLOCK_SIZE         0x10000
 #define FVB_MEDIA_BLOCK_SIZE        FIRMWARE_BLOCK_SIZE
-
-#define NV_STORAGE_BASE_ADDRESS     FixedPcdGet32(PcdFlashNvStorageVariableBase)
-#define SYSTEM_NV_BLOCK_NUM         ((FixedPcdGet32(PcdFlashNvStorageVariableSize)+ FixedPcdGet32(PcdFlashNvStorageFtwWorkingSize) + FixedPcdGet32(PcdFlashNvStorageFtwSpareSize))/ FVB_MEDIA_BLOCK_SIZE)
-
 typedef struct {
   EFI_PHYSICAL_ADDRESS        BaseAddress;
   EFI_FIRMWARE_VOLUME_HEADER  FvbInfo;
   EFI_FV_BLOCK_MAP_ENTRY      End[1];
 } EFI_FVB2_MEDIA_INFO;
 
-//
-// This data structure contains a template of all correct FV headers, which is used to restore
-// Fv header if it's corrupted.
-//
-EFI_FVB2_MEDIA_INFO mPlatformFvbMediaInfo[] = {
-  //
-  // Systen NvStorage FVB
-  //
-  {
-    NV_STORAGE_BASE_ADDRESS,
-    {
-      {0,}, //ZeroVector[16]
-      EFI_SYSTEM_NV_DATA_FV_GUID,
-      FVB_MEDIA_BLOCK_SIZE * SYSTEM_NV_BLOCK_NUM,
-      EFI_FVH_SIGNATURE,
-      0x0004feff, // check MdePkg/Include/Pi/PiFirmwareVolume.h for details on EFI_FVB_ATTRIBUTES_2
-      sizeof (EFI_FIRMWARE_VOLUME_HEADER) + sizeof (EFI_FV_BLOCK_MAP_ENTRY),
-      0,    //CheckSum which will be calucated dynamically.
-      0,    //ExtHeaderOffset
-      {0,}, //Reserved[1]
-      2,    //Revision
-      {
-        {
-          SYSTEM_NV_BLOCK_NUM,
-          FVB_MEDIA_BLOCK_SIZE,
-        }
-      }
-    },
-    {
-      {
-        0,
-        0
-      }
-    }
+// MU_CHANGE - START - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
+/**
+  Returns FVB media information for NV variable storage.
+
+  @return       FvbMediaInfo          A pointer to an instance of FVB media info produced by this function.
+                                      The buffer is allocated internally to this function and it is the caller's
+                                      responsibility to free the memory
+
+**/
+typedef
+EFI_STATUS
+(*FVB_MEDIA_INFO_GENERATOR)(
+  OUT EFI_FVB2_MEDIA_INFO     *FvbMediaInfo
+  );
+
+/**
+  Returns FVB media information for NV variable storage.
+
+  @return       FvbMediaInfo          A pointer to an instance of FVB media info produced by this function.
+                                      The buffer is allocated internally to this function and it is the caller's
+                                      responsibility to free the memory
+
+**/
+EFI_STATUS
+GenerateNvStorageFvbMediaInfo (
+  OUT EFI_FVB2_MEDIA_INFO     *FvbMediaInfo
+  )
+{
+  EFI_STATUS                  Status;
+  UINT32                      NvBlockNum;
+  UINT32                      NvStorageVariableSize;
+  UINT64                      TotalNvVariableStorageSize;
+  EFI_PHYSICAL_ADDRESS        NvStorageBaseAddress;
+  EFI_FIRMWARE_VOLUME_HEADER  FvbInfo = {
+                                          {0,},                                   //ZeroVector[16]
+                                          EFI_SYSTEM_NV_DATA_FV_GUID,             //FileSystemGuid
+                                          0,                                      //FvLength
+                                          EFI_FVH_SIGNATURE,                      //Signature
+                                          0x0004feff,                             //Attributes
+                                          sizeof (EFI_FIRMWARE_VOLUME_HEADER) +   //HeaderLength
+                                            sizeof (EFI_FV_BLOCK_MAP_ENTRY),
+                                          0,                                      //Checksum
+                                          0,                                      //ExtHeaderOffset
+                                          {0,},                                   //Reserved[1]
+                                          2,                                      //Revision
+                                          {                                       //BlockMap[1]
+                                            {0,0}
+                                          }
+                                        };
+
+  if (FvbMediaInfo == NULL) {
+    return EFI_INVALID_PARAMETER;
   }
+
+  GetVariableFlashInfo (&NvStorageBaseAddress, &NvStorageVariableSize);
+
+  ZeroMem (FvbMediaInfo, sizeof (*FvbMediaInfo));
+
+  TotalNvVariableStorageSize =  (UINT64)NvStorageBaseAddress +
+                                  (UINT64)FixedPcdGet32 (PcdFlashNvStorageFtwWorkingSize);
+  Status =  SafeUint64Add (
+              TotalNvVariableStorageSize,
+              (UINT64)FixedPcdGet32(PcdFlashNvStorageFtwSpareSize),
+              &TotalNvVariableStorageSize
+              );
+  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Status = SafeUint64ToUint32 (TotalNvVariableStorageSize / FVB_MEDIA_BLOCK_SIZE, &NvBlockNum);
+  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  FvbInfo.FvLength = (UINT64)(NvBlockNum * FVB_MEDIA_BLOCK_SIZE);
+  FvbInfo.BlockMap[0].NumBlocks = NvBlockNum;
+  FvbInfo.BlockMap[0].Length = FVB_MEDIA_BLOCK_SIZE;
+
+  FvbMediaInfo->BaseAddress = NvStorageBaseAddress;
+  CopyMem (&FvbMediaInfo->FvbInfo, &FvbInfo, sizeof (FvbInfo));
+
+  return EFI_SUCCESS;
+}
+
+FVB_MEDIA_INFO_GENERATOR mFvbMediaInfoGenerators[] = {
+  GenerateNvStorageFvbMediaInfo
 };
+// MU_CHANGE - END - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
 
 EFI_STATUS
 GetFvbInfo (
@@ -64,13 +115,20 @@ GetFvbInfo (
   OUT EFI_FIRMWARE_VOLUME_HEADER   **FvbInfo
   )
 {
+  // MU_CHANGE - START - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
+  EFI_STATUS                  Status;
+  EFI_FVB2_MEDIA_INFO         FvbMediaInfo;
+  // MU_CHANGE - END - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
   UINTN                       Index;
   EFI_FIRMWARE_VOLUME_HEADER  *FvHeader;
 
-  for (Index = 0; Index < sizeof (mPlatformFvbMediaInfo) / sizeof (EFI_FVB2_MEDIA_INFO); Index++) {
-    if (mPlatformFvbMediaInfo[Index].BaseAddress == FvBaseAddress) {
-      FvHeader = &mPlatformFvbMediaInfo[Index].FvbInfo;
-
+  // MU_CHANGE - START - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
+  for (Index = 0; Index < ARRAY_SIZE (mFvbMediaInfoGenerators); Index++) {
+    Status = mFvbMediaInfoGenerators[Index](&FvbMediaInfo);
+    ASSERT_EFI_ERROR (Status);
+    if (!EFI_ERROR (Status) && (FvbMediaInfo.BaseAddress == FvBaseAddress)) {
+      FvHeader = &FvbMediaInfo.FvbInfo;
+  // MU_CHANGE - END - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
       //
       // Update the checksum value of FV header.
       //

--- a/MinPlatformPkg/Flash/SpiFvbService/SpiFvbServiceCommon.c
+++ b/MinPlatformPkg/Flash/SpiFvbService/SpiFvbServiceCommon.c
@@ -25,12 +25,6 @@ FV_INFO mPlatformFvBaseAddress[] = {
   {0, 0}
 };
 
-FV_INFO mPlatformDefaultBaseAddress[] = {
-  {0, 0}, // {FixedPcdGet32(PcdFlashNvStorageVariableBase), FixedPcdGet32(PcdFlashNvStorageVariableSize)},
-  {0, 0}, // {FixedPcdGet32(PcdFlashFvMicrocodeBase), FixedPcdGet32(PcdFlashFvMicrocodeSize)},
-  {0, 0}
-};
-
 FV_MEMMAP_DEVICE_PATH mFvMemmapDevicePathTemplate = {
   {
     {
@@ -530,6 +524,59 @@ FvbSetVolumeAttributes (
   return EFI_SUCCESS;
 }
 
+// MU_CHANGE - START - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
+/**
+  Get the HOB that contains variable flash information.
+
+  @param[out] BaseAddress         Base address of the variable store.
+  @param[out] Length              Length in bytes of the variable store.
+
+**/
+VOID
+GetVariableFlashInfo (
+  OUT EFI_PHYSICAL_ADDRESS      *BaseAddress,
+  OUT UINT32                    *Length
+  )
+{
+  EFI_STATUS                    Status;
+  EFI_HOB_GUID_TYPE             *GuidHob;
+  VARIABLE_FLASH_INFO           *VariableFlashInfo;
+
+  Status = EFI_SUCCESS;
+
+  if ((BaseAddress == NULL) || (Length == NULL)) {
+    ASSERT ((BaseAddress != NULL) && (Length != NULL));
+    return;
+  }
+
+  GuidHob = GetFirstGuidHob (&gVariableFlashInfoHobGuid);
+  if (GuidHob != NULL) {
+    DEBUG ((DEBUG_INFO, "[%a] - Variable Flash Info HOB found.\n", __FUNCTION__));
+    VariableFlashInfo = GET_GUID_HOB_DATA (GuidHob);
+    *BaseAddress = VariableFlashInfo->BaseAddress;
+    Status = SafeUint64ToUint32 (VariableFlashInfo->Length, Length);
+    // Stay within the current UINT32 size assumptions in the variable stack.
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  if (GuidHob == NULL || EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "[%a] - Unable to use Variable Flash Info HOB. Using PCD values.\n", __FUNCTION__));
+    *BaseAddress = (EFI_PHYSICAL_ADDRESS)PcdGet32 (PcdFlashNvStorageVariableBase);
+    *Length = PcdGet32 (PcdFlashNvStorageVariableSize);
+  }
+
+  //
+  // Assert if more than one variable flash information HOB is present.
+  //
+  DEBUG_CODE (
+    if ((GuidHob != NULL) && (GetNextGuidHob (&gVariableFlashInfoHobGuid, GET_NEXT_HOB (GuidHob)) != NULL)) {
+      DEBUG ((DEBUG_ERROR, "ERROR: Found two variable flash information HOBs\n"));
+      ASSERT (FALSE);
+    }
+    );
+}
+// MU_CHANGE - END - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
+
 /**
   Check the integrity of firmware volume header
 
@@ -545,7 +592,14 @@ IsFvHeaderValid (
   IN CONST EFI_FIRMWARE_VOLUME_HEADER    *FvHeader
   )
 {
-  if (FvBase == PcdGet32(PcdFlashNvStorageVariableBase)) {
+  // MU_CHANGE - START - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
+  EFI_PHYSICAL_ADDRESS    NvStorageFvBaseAddress;
+  UINT32                  NvStorageSize;
+
+  GetVariableFlashInfo (&NvStorageFvBaseAddress, &NvStorageSize);
+
+  if (FvBase == NvStorageFvBaseAddress) {
+  // MU_CHANGE - END - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
     if (CompareMem (&FvHeader->FileSystemGuid, &gEfiSystemNvDataFvGuid, sizeof(EFI_GUID)) != 0 ) {
       return FALSE;
     }

--- a/MinPlatformPkg/Flash/SpiFvbService/SpiFvbServiceCommon.h
+++ b/MinPlatformPkg/Flash/SpiFvbService/SpiFvbServiceCommon.h
@@ -12,6 +12,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/EventGroup.h>
 #include <Guid/FirmwareFileSystem2.h>
 #include <Guid/SystemNvDataGuid.h>
+#include <Guid/VariableFlashInfo.h>       // MU_CHANGE TCBZ3478 - Add Dynamic Variable Store and Microcode Support
+#include <Pi/PiFirmwareVolume.h>          // MU_CHANGE TCBZ3478 - Add Dynamic Variable Store and Microcode Support
 #include <Protocol/DevicePath.h>
 #include <Protocol/FirmwareVolumeBlock.h>
 
@@ -24,6 +26,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PcdLib.h>
 #include <Library/DevicePathLib.h>
 #include <Library/HobLib.h>
+#include <Library/SafeIntLib.h>           // MU_CHANGE TCBZ3478 - Add Dynamic Variable Store and Microcode Support
 
 #include <Library/SpiFlashCommonLib.h>
 
@@ -148,11 +151,25 @@ GetFvbInfo (
   OUT EFI_FIRMWARE_VOLUME_HEADER   **FvbInfo
   );
 
+// MU_CHANGE - START - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
+/**
+  Get the HOB that contains variable flash information.
+
+  @param[out] BaseAddress         Base address of the variable store.
+  @param[out] Length              Length in bytes of the variable store.
+
+**/
+VOID
+GetVariableFlashInfo (
+  OUT EFI_PHYSICAL_ADDRESS      *BaseAddress,
+  OUT UINT32                    *Length
+  );
+// MU_CHANGE - END - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
+
 extern FVB_GLOBAL                         mFvbModuleGlobal;
 extern FV_MEMMAP_DEVICE_PATH              mFvMemmapDevicePathTemplate;
 extern FV_PIWG_DEVICE_PATH                mFvPIWGDevicePathTemplate;
 extern EFI_FIRMWARE_VOLUME_BLOCK_PROTOCOL mFvbProtocolTemplate;
 extern FV_INFO                            mPlatformFvBaseAddress[];
-extern FV_INFO                            mPlatformDefaultBaseAddress[];
 
 #endif

--- a/MinPlatformPkg/Flash/SpiFvbService/SpiFvbServiceMm.c
+++ b/MinPlatformPkg/Flash/SpiFvbService/SpiFvbServiceMm.c
@@ -114,14 +114,18 @@ FvbInitialize (
   UINT32                                BytesWritten;
   UINTN                                 BytesErased;
 
-  mPlatformFvBaseAddress[0].FvBase = PcdGet32(PcdFlashNvStorageVariableBase);
-  mPlatformFvBaseAddress[0].FvSize = PcdGet32(PcdFlashNvStorageVariableSize);
+  // MU_CHANGE - START - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
+  GetVariableFlashInfo (&BaseAddress, &mPlatformFvBaseAddress[0].FvSize);
+  Status = SafeUint64ToUint32 (BaseAddress, &mPlatformFvBaseAddress[0].FvBase);
+  ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "[%a] - 64-bit variable storage base address not supported.\n", __FUNCTION__));
+    return;
+  }
+
   mPlatformFvBaseAddress[1].FvBase = PcdGet32(PcdFlashFvMicrocodeBase);
   mPlatformFvBaseAddress[1].FvSize = PcdGet32(PcdFlashFvMicrocodeSize);
-  mPlatformDefaultBaseAddress[0].FvBase = PcdGet32(PcdFlashNvStorageVariableBase);
-  mPlatformDefaultBaseAddress[0].FvSize = PcdGet32(PcdFlashNvStorageVariableSize);
-  mPlatformDefaultBaseAddress[1].FvBase = PcdGet32(PcdFlashFvMicrocodeBase);
-  mPlatformDefaultBaseAddress[1].FvSize = PcdGet32(PcdFlashFvMicrocodeSize);
+  // MU_CHANGE - END - TCBZ3478 - Add Dynamic Variable Store and Microcode Support
 
   //
   // We will only continue with FVB installation if the

--- a/MinPlatformPkg/Flash/SpiFvbService/SpiFvbServiceSmm.inf
+++ b/MinPlatformPkg/Flash/SpiFvbService/SpiFvbServiceSmm.inf
@@ -30,8 +30,10 @@
   BaseMemoryLib
   DebugLib
   BaseLib
+  HobLib                    # MU_CHANGE TCBZ3478 - Add Dynamic Variable Store and Microcode Support
   UefiBootServicesTableLib
   UefiDriverEntryPoint
+  SafeIntLib                # MU_CHANGE TCBZ3478 - Add Dynamic Variable Store and Microcode Support
   SpiFlashCommonLib
   MmServicesTableLib
 
@@ -63,6 +65,7 @@
 [Guids]
   gEfiFirmwareFileSystem2Guid                   ## CONSUMES
   gEfiSystemNvDataFvGuid                        ## CONSUMES
+  gVariableFlashInfoHobGuid                     ## CONSUMES  # MU_CHANGE TCBZ3478 - Add Dynamic Variable Store and Microcode Support
 
 [Depex]
   TRUE

--- a/MinPlatformPkg/Flash/SpiFvbService/SpiFvbServiceStandaloneMm.inf
+++ b/MinPlatformPkg/Flash/SpiFvbService/SpiFvbServiceStandaloneMm.inf
@@ -28,9 +28,11 @@
   BaseMemoryLib
   CacheMaintenanceLib
   DebugLib
+  HobLib                    # MU_CHANGE TCBZ3478 - Add Dynamic Variable Store and Microcode Support
   MemoryAllocationLib
   PcdLib
   MmServicesTableLib
+  SafeIntLib                # MU_CHANGE TCBZ3478 - Add Dynamic Variable Store and Microcode Support
   SpiFlashCommonLib
   StandaloneMmDriverEntryPoint
 
@@ -62,6 +64,7 @@
 [Guids]
   gEfiFirmwareFileSystem2Guid                   ## CONSUMES
   gEfiSystemNvDataFvGuid                        ## CONSUMES
+  gVariableFlashInfoHobGuid                     ## CONSUMES  # MU_CHANGE TCBZ3478 - Add Dynamic Variable Store and Microcode Support
 
 [Depex]
   TRUE


### PR DESCRIPTION
The current implementation assumes PCDs containing information about
FV base and size such as those for the variable store FV are
FixedAtBuild. These PCDs and others could be treated as dynamic by
a particular platform so the module is updated to read dynamic (in
addition to FixedAtBuild) PCDs.

In addition, dynamic PCDs are not available in Standalone MM. So
the code also checks if a variable flash information HOB is present
before consuming the flash information from PCDs.

This change focuses on the variable base and size as these are the
primary configuration values adjusted by platforms and directly
consumed by the UEFI varible drivers. Future changes might add
similar support for the fault tolerant PCDs and microcode PCDs.