### PR TITLE
[TCBZ3541] MinPlatformPkg/TestPointCheckLib: Add support for BME device exemption

### DIFF
--- a/MinPlatformPkg/MinPlatformPkg.dec
+++ b/MinPlatformPkg/MinPlatformPkg.dec
@@ -158,6 +158,12 @@
   #   Stage Advanced:                                             {0x03, 0x0F, 0x03, 0x1D, 0x3F, 0x0F, 0x0F, 0x07, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
   gMinPlatformPkgTokenSpaceGuid.PcdTestPointIbvPlatformFeature|{0x03, 0x0F, 0x03, 0x1D, 0x3F, 0x0F, 0x0F, 0x07, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}|VOID*|0x00100302
 
+  # MU_CHANGE - BEGIN - TCBZ3541
+  # The platform may define a list of devices that are exempt from PCI BME testing.
+  # PCD Format is {SegmentNumber1, BusNumber1, DeviceNumber1, FunctionNumber1, SegmentNumber2, BusNumber2, DeviceNumber2, FunctionNumber2, ...}
+  gMinPlatformPkgTokenSpaceGuid.PcdTestPointIbvPlatformExemptPciBme|{0}|VOID*|0x00100303
+  # MU_CHANGE - END - TCBZ3541
+
   ##
   ## The Flash relevant PCD are ineffective and will be patched basing on FDF definitions during build.
   ## Set all of them to 0 here to prevent from confusion.

--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckPci.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckPci.c
@@ -44,6 +44,15 @@ typedef struct {
   UINT32                        Data[48];
 } PCI_CONFIG_SPACE;
 
+// MU_CHANGE - BEGIN - TCBZ3541
+typedef struct {
+  UINT8 Segment;
+  UINT8 Bus;
+  UINT8 Device;
+  UINT8 Function;
+} EXEMPT_DEVICE;
+// MU_CHANGE - END - TCBZ3541
+
 #pragma pack()
 
 VOID
@@ -256,7 +265,7 @@ TestPointCheckPciResource (
   UINT16                            MinBus;
   UINT16                            MaxBus;
   BOOLEAN                           IsEnd;
-  
+
   DEBUG ((DEBUG_INFO, "==== TestPointCheckPciResource - Enter\n"));
   HandleBuf = NULL;
   Status = gBS->LocateHandleBuffer (
@@ -338,7 +347,7 @@ TestPointCheckPciResource (
                 // Device
                 DumpPciDevice ((UINT8)Bus, (UINT8)Device, (UINT8)Func, &PciData);
               }
-              
+
               //
               // If this is not a multi-function device, we can leave the loop
               // to deal with the next device.
@@ -360,7 +369,7 @@ TestPointCheckPciResource (
       }
     }
   }
-  
+
 Done:
   if (HandleBuf != NULL) {
     FreePool (HandleBuf);
@@ -396,6 +405,11 @@ TestPointCheckPciBusMaster (
   UINT8             HeaderType;
   EFI_STATUS        Status;
   PCI_SEGMENT_INFO  *PciSegmentInfo;
+  // MU_CHANGE - BEGIN - TCBZ3541
+  EXEMPT_DEVICE     *ExemptDevicePcdPtr;
+  BOOLEAN           ExemptDeviceFound;
+  UINTN             Index;
+  // MU_CHANGE - END - TCBZ3541
 
   PciSegmentInfo = GetPciSegmentInfo (&SegmentCount);
   if (PciSegmentInfo == NULL) {
@@ -407,6 +421,29 @@ TestPointCheckPciBusMaster (
     for (Bus = PciSegmentInfo[Segment].StartBusNumber; Bus <= PciSegmentInfo[Segment].EndBusNumber; Bus++) {
       for (Device = 0; Device <= 0x1F; Device++) {
         for (Function = 0; Function <= 0x7; Function++) {
+          // MU_CHANGE - BEGIN - TCBZ3541
+          //
+          // Some platforms have devices which do not expose any additional
+          // risk of DMA attacks but are not able to be turned off.  Allow
+          // the platform to define these devices and do not record errors
+          // for these devices.
+          //
+          ExemptDevicePcdPtr = (EXEMPT_DEVICE *) PcdGetPtr (PcdTestPointIbvPlatformExemptPciBme);
+          ExemptDeviceFound = FALSE;
+          for (Index = 0; Index < (PcdGetSize (PcdTestPointIbvPlatformExemptPciBme) / sizeof (EXEMPT_DEVICE)); Index++) {
+            if (Segment == ExemptDevicePcdPtr[Index].Segment
+                && Bus == ExemptDevicePcdPtr[Index].Bus
+                && Device == ExemptDevicePcdPtr[Index].Device
+                && Function == ExemptDevicePcdPtr[Index].Function) {
+              ExemptDeviceFound = TRUE;
+            }
+          }
+
+          if (ExemptDeviceFound) {
+            continue;
+          }
+          // MU_CHANGE - END - TCBZ3541
+
           VendorId = PciSegmentRead16 (PCI_SEGMENT_LIB_ADDRESS(PciSegmentInfo[Segment].SegmentNumber, Bus, Device, Function, PCI_VENDOR_ID_OFFSET));
           //
           // If VendorId = 0xffff, there does not exist a device at this

--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeTestPointCheckLib.inf
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeTestPointCheckLib.inf
@@ -108,3 +108,4 @@
 
 [Pcd]
   gMinPlatformPkgTokenSpaceGuid.PcdTestPointIbvPlatformFeature
+  gMinPlatformPkgTokenSpaceGuid.PcdTestPointIbvPlatformExemptPciBme # MU_CHANGE - TCBZ3541

--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/PeiCheckPci.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/PeiCheckPci.c
@@ -14,6 +14,19 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PciSegmentInfoLib.h>
 #include <IndustryStandard/Pci.h>
 
+// MU_CHANGE - BEGIN - TCBZ3541
+#pragma pack(1)
+
+ typedef struct EXEMPT_DEVICE_STRUCT {
+  UINT8 Segment;
+  UINT8 Bus;
+  UINT8 Device;
+  UINT8 Function;
+} EXEMPT_DEVICE;
+
+#pragma pack()
+// MU_CHANGE - END - TCBZ3541
+
 EFI_STATUS
 TestPointCheckPciBusMaster (
   VOID
@@ -29,6 +42,11 @@ TestPointCheckPciBusMaster (
   UINT8             HeaderType;
   EFI_STATUS        Status;
   PCI_SEGMENT_INFO  *PciSegmentInfo;
+  // MU_CHANGE - BEGIN - TCBZ3541
+  EXEMPT_DEVICE     *ExemptDevicePcdPtr;
+  BOOLEAN           ExemptDeviceFound;
+  UINTN             Index;
+  // MU_CHANGE - END - TCBZ3541
 
   PciSegmentInfo = GetPciSegmentInfo (&SegmentCount);
   if (PciSegmentInfo == NULL) {
@@ -40,6 +58,29 @@ TestPointCheckPciBusMaster (
     for (Bus = PciSegmentInfo[Segment].StartBusNumber; Bus <= PciSegmentInfo[Segment].EndBusNumber; Bus++) {
       for (Device = 0; Device <= 0x1F; Device++) {
         for (Function = 0; Function <= 0x7; Function++) {
+          // MU_CHANGE - BEGIN - TCBZ3541
+          //
+          // Some platforms have devices which do not expose any additional
+          // risk of DMA attacks but are not able to be turned off.  Allow
+          // the platform to define these devices and do not record errors
+          // for these devices.
+          //
+          ExemptDevicePcdPtr = (EXEMPT_DEVICE *) PcdGetPtr (PcdTestPointIbvPlatformExemptPciBme);
+          ExemptDeviceFound = FALSE;
+          for (Index = 0; Index < (PcdGetSize (PcdTestPointIbvPlatformExemptPciBme) / sizeof (EXEMPT_DEVICE)); Index++) {
+            if (Segment == ExemptDevicePcdPtr[Index].Segment
+                && Bus == ExemptDevicePcdPtr[Index].Bus
+                && Device == ExemptDevicePcdPtr[Index].Device
+                && Function == ExemptDevicePcdPtr[Index].Function) {
+              ExemptDeviceFound = TRUE;
+            }
+          }
+
+          if (ExemptDeviceFound) {
+            continue;
+          }
+          // MU_CHANGE - END - TCBZ3541
+
           VendorId = PciSegmentRead16 (PCI_SEGMENT_LIB_ADDRESS(PciSegmentInfo[Segment].SegmentNumber, Bus, Device, Function, PCI_VENDOR_ID_OFFSET));
           //
           // If VendorId = 0xffff, there does not exist a device at this

--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/PeiTestPointCheckLib.inf
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/PeiTestPointCheckLib.inf
@@ -47,6 +47,7 @@
 
 [Pcd]
   gMinPlatformPkgTokenSpaceGuid.PcdTestPointIbvPlatformFeature
+  gMinPlatformPkgTokenSpaceGuid.PcdTestPointIbvPlatformExemptPciBme # MU_CHANGE - TCBZ3541
 
 [Guids]
   gEfiHobMemoryAllocStackGuid


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3541

Some platforms have devices which do not expose any additional
risk of DMA attacks but the BME bit cannot be disabled.

To allow MinPlatformPkg consumers to selectively exempt certain
devices from the PCI bus master test point, this change adds a
PCD to MinPlatformPkg.dec that allows those packages to specify
a list of PCI devices by S/B/D/F that should be excluded from
testing.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Eric Dong <eric.dong@intel.com>
Cc: Chris Ruffin <v-chruff@microsoft.com>
Co-authored-by: Michael Kubacki <michael.kubacki@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>