### PR TITLE
Move Platform Lockdown to EndOfDxe event (rather than SmmReadyToLock) and defer it until ReadyToBoot for update flows.

### DIFF
--- a/MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.c
+++ b/MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.c
@@ -9,50 +9,36 @@
 #include <PiDxe.h>
 
 #include <Library/DebugLib.h>
+#include <Library/HobLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
 #include <Library/TpmPlatformHierarchyLib.h>
 #include <Protocol/DxeSmmReadyToLock.h>
 
 /**
-   This callback function will run at the SmmReadyToLock event.
+   This callback function will run at EndOfDxe or ReadyToBoot based on boot mode.
 
    Configuration of the TPM's Platform Hierarchy Authorization Value (platformAuth)
    and Platform Hierarchy Authorization Policy (platformPolicy) can be defined through this function.
 
   @param  Event   Pointer to this event
-  @param  Context Event hanlder private data
+  @param  Context Event handler private data
  **/
 VOID
 EFIAPI
-SmmReadyToLockEventCallBack (
+TpmReadyToLockEventCallBack (
   IN EFI_EVENT  Event,
   IN VOID       *Context
   )
 {
-  EFI_STATUS   Status;
-  VOID         *Interface;
-
-  //
-  // Try to locate it because EfiCreateProtocolNotifyEvent will trigger it once when registration.
-  // Just return if it is not found.
-  //
-  Status = gBS->LocateProtocol (
-                  &gEfiDxeSmmReadyToLockProtocolGuid,
-                  NULL,
-                  &Interface
-                  );
-  if (EFI_ERROR (Status)) {
-    return ;
-  }
-
+  DEBUG ((DEBUG_INFO, "[%a] Disabling TPM Platform Hierarchy\n", __FUNCTION__));
   ConfigureTpmPlatformHierarchy ();
 
   gBS->CloseEvent (Event);
 }
 
 /**
-   The driver's entry point. Will register a function for callback during SmmReadyToLock event to
+   The driver's entry point. Will register a function for callback during ReadyToBoot event to
    configure the TPM's platform authorization.
 
    @param[in] ImageHandle  The firmware allocated handle for the EFI image.
@@ -68,18 +54,28 @@ Tcg2PlatformDxeEntryPoint (
   IN    EFI_SYSTEM_TABLE            *SystemTable
   )
 {
-  VOID       *Registration;
-  EFI_EVENT  Event;
+  EFI_STATUS    Status;
+  EFI_BOOT_MODE BootMode;
+  EFI_EVENT     Event;
 
-  Event = EfiCreateProtocolNotifyEvent (
-            &gEfiDxeSmmReadyToLockProtocolGuid,
-            TPL_CALLBACK,
-            SmmReadyToLockEventCallBack,
-            NULL,
-            &Registration
-            );
+  BootMode = GetBootModeHob ();
 
-  ASSERT (Event != NULL);
+  // In flash update boot path, leave TPM Platform Hierarchy enabled until ReadyToBoot (which should never actually
+  // occur, since capsule reset will occur first).
+  if (BootMode == BOOT_ON_FLASH_UPDATE) {
+    Status = EfiCreateEventReadyToBootEx (TPL_CALLBACK, TpmReadyToLockEventCallBack, NULL, &Event);
+  } else {
+    // In all other boot paths, disable TPM Platform Hierarchy at EndOfDxe.
+    Status = gBS->CreateEventEx (
+                    EVT_NOTIFY_SIGNAL,
+                    TPL_CALLBACK,
+                    TpmReadyToLockEventCallBack,
+                    NULL,
+                    &gEfiEndOfDxeEventGroupGuid,
+                    &Event
+                    );
+  }
+  ASSERT_EFI_ERROR (Status);
 
   return EFI_SUCCESS;
 }

--- a/MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.c
+++ b/MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.c
@@ -6,6 +6,8 @@
 
 **/
 
+// MU_CHANGE - START refactor Tcg2PlatformDxe to lock TPM at EndOfDxe or ReadyToBoot depending on boot mode.
+
 #include <PiDxe.h>
 
 #include <Library/DebugLib.h>
@@ -79,3 +81,4 @@ Tcg2PlatformDxeEntryPoint (
 
   return EFI_SUCCESS;
 }
+// MU_CHANGE - END refactor Tcg2PlatformDxe to lock TPM at EndOfDxe or ReadyToBoot depending on boot mode.

--- a/MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
+++ b/MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
@@ -25,7 +25,7 @@
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   DebugLib
-  HobLib
+  HobLib # MU_CHANGE - refactor Tcg2PlatformDxe to lock TPM at EndOfDxe or ReadyToBoot depending on boot mode.
   UefiLib
   TpmPlatformHierarchyLib
 
@@ -38,8 +38,10 @@
 [Sources]
   Tcg2PlatformDxe.c
 
+# MU_CHANGE - START refactor Tcg2PlatformDxe to lock TPM at EndOfDxe or ReadyToBoot depending on boot mode.
 [Guids]
   gEfiEndOfDxeEventGroupGuid             ## SOMETIMES_CONSUMES ## NOTIFY
+# MU_CHANGE - END refactor Tcg2PlatformDxe to lock TPM at EndOfDxe or ReadyToBoot depending on boot mode.
 
 [Depex]
   gEfiTcg2ProtocolGuid

--- a/MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
+++ b/MinPlatformPkg/Tcg/Tcg2PlatformDxe/Tcg2PlatformDxe.inf
@@ -25,6 +25,7 @@
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   DebugLib
+  HobLib
   UefiLib
   TpmPlatformHierarchyLib
 
@@ -37,8 +38,8 @@
 [Sources]
   Tcg2PlatformDxe.c
 
-[Protocols]
-  gEfiDxeSmmReadyToLockProtocolGuid             ## SOMETIMES_CONSUMES ## NOTIFY
+[Guids]
+  gEfiEndOfDxeEventGroupGuid             ## SOMETIMES_CONSUMES ## NOTIFY
 
 [Depex]
   gEfiTcg2ProtocolGuid


### PR DESCRIPTION
TPM update flows typically require Platform Auth and typically capsule processor runs in BDS, so deferring until ReadyToBoot in BOOT_ON_FLASH_UPDATE permits TPM capsule update to complete.