### PR TITLE
TCBZ3768 MinPlatformPkg/TestPointCheckLib: Fix DMAR structure length calculation

### DIFF
--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckAcpiDmar.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckAcpiDmar.c
@@ -127,13 +127,15 @@ DumpAcpiDmar (
   DumpAcpiTableHeader (&Dmar->Header);
   DEBUG ((DEBUG_INFO, "         "));
   DEBUG ((DEBUG_INFO, " HostAddressWidth=0x%02x Flags=0x%02x\n", Dmar->HostAddressWidth, Dmar->Flags));
-    
+
   //
   // Sub table
   //
   DmarLen  = Dmar->Header.Length - sizeof(EFI_ACPI_DMAR_HEADER);
   DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)(Dmar + 1);
-  while (DmarLen > 0) {
+  // MU_CHANGE TCBZ3768: BEGIN - DMAR structure length calculation in TestPointCheckLib is invalid
+  while (DmarLen >= sizeof (*DmarStructHeader)) {
+  // MU_CHANGE TCBZ3768: END - DMAR structure length calculation in TestPointCheckLib is invalid
     switch (DmarStructHeader->Type) {
     case EFI_ACPI_DMAR_TYPE_DRHD:
       Drhd = (EFI_ACPI_DMAR_DRHD_HEADER *)DmarStructHeader;
@@ -204,8 +206,10 @@ DumpAcpiDmar (
       DEBUG ((DEBUG_INFO, "\n"));
       break;
     }
-    DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)((UINT8 *)DmarStructHeader + DmarStructHeader->Length);
+    // MU_CHANGE TCBZ3768: BEGIN - DMAR structure length calculation in TestPointCheckLib is invalid
     DmarLen         -= DmarStructHeader->Length;
+    DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)((UINT8 *)DmarStructHeader + DmarStructHeader->Length);
+    // MU_CHANGE TCBZ3768: END - DMAR structure length calculation in TestPointCheckLib is invalid
   }
 }
 
@@ -217,10 +221,12 @@ CheckAcpiDmar (
   EFI_ACPI_DMAR_STRUCTURE_HEADER        *DmarStructHeader;
   INTN                                  DmarLen;
   EFI_ACPI_DMAR_DRHD_HEADER             *Drhd;
-    
+
   DmarLen  = Dmar->Header.Length - sizeof(EFI_ACPI_DMAR_HEADER);
   DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)(Dmar + 1);
-  while (DmarLen > 0) {
+  // MU_CHANGE TCBZ3768: BEGIN - DMAR structure length calculation in TestPointCheckLib is invalid
+  while (DmarLen >= sizeof (*DmarStructHeader)) {
+  // MU_CHANGE TCBZ3768: END - DMAR structure length calculation in TestPointCheckLib is invalid
     switch (DmarStructHeader->Type) {
     case EFI_ACPI_DMAR_TYPE_DRHD:
       Drhd = (EFI_ACPI_DMAR_DRHD_HEADER *)DmarStructHeader;
@@ -232,8 +238,10 @@ CheckAcpiDmar (
     default:
       break;
     }
-    DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)((UINT8 *)DmarStructHeader + DmarStructHeader->Length);
+    // MU_CHANGE TCBZ3768: BEGIN - DMAR structure length calculation in TestPointCheckLib is invalid
     DmarLen         -= DmarStructHeader->Length;
+    DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)((UINT8 *)DmarStructHeader + DmarStructHeader->Length);
+    // MU_CHANGE TCBZ3768: END - DMAR structure length calculation in TestPointCheckLib is invalid
   }
   return EFI_SUCCESS;
 }

--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckDmaProtection.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckDmaProtection.c
@@ -32,13 +32,15 @@ CheckDrhd (
   INTN                                  DmarLen;
   EFI_ACPI_DMAR_DRHD_HEADER             *Drhd;
   UINT32                                Reg32;
-    
+
   //
   // Sub table
   //
   DmarLen  = Dmar->Header.Length - sizeof(EFI_ACPI_DMAR_HEADER);
   DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)(Dmar + 1);
-  while (DmarLen > 0) {
+  // MU_CHANGE TCBZ3768: BEGIN - DMAR structure length calculation in TestPointCheckLib is invalid
+  while (DmarLen >= sizeof (*DmarStructHeader)) {
+  // MU_CHANGE TCBZ3768: END - DMAR structure length calculation in TestPointCheckLib is invalid
     switch (DmarStructHeader->Type) {
     case EFI_ACPI_DMAR_TYPE_DRHD:
       Drhd = (EFI_ACPI_DMAR_DRHD_HEADER *)DmarStructHeader;
@@ -56,8 +58,10 @@ CheckDrhd (
     default:
       break;
     }
-    DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)((UINT8 *)DmarStructHeader + DmarStructHeader->Length);
+    // MU_CHANGE TCBZ3768: BEGIN - DMAR structure length calculation in TestPointCheckLib is invalid
     DmarLen         -= DmarStructHeader->Length;
+    DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)((UINT8 *)DmarStructHeader + DmarStructHeader->Length);
+    // MU_CHANGE TCBZ3768: END - DMAR structure length calculation in TestPointCheckLib is invalid
   }
 
   return EFI_SUCCESS;

--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/PeiCheckDmaProtection.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/PeiCheckDmaProtection.c
@@ -30,13 +30,15 @@ CheckDrhd (
   EFI_ACPI_DMAR_DRHD_HEADER             *Drhd;
   UINT32                                Reg32;
   VTD_CAP_REG                           CapReg;
-    
+
   //
   // Sub table
   //
   DmarLen  = Dmar->Header.Length - sizeof(EFI_ACPI_DMAR_HEADER);
   DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)(Dmar + 1);
-  while (DmarLen > 0) {
+  // MU_CHANGE TCBZ3768: BEGIN - DMAR structure length calculation in TestPointCheckLib is invalid
+  while (DmarLen >= sizeof (*DmarStructHeader)) {
+  // MU_CHANGE TCBZ3768: END - DMAR structure length calculation in TestPointCheckLib is invalid
     switch (DmarStructHeader->Type) {
     case EFI_ACPI_DMAR_TYPE_DRHD:
       Drhd = (EFI_ACPI_DMAR_DRHD_HEADER *)DmarStructHeader;
@@ -61,8 +63,10 @@ CheckDrhd (
     default:
       break;
     }
-    DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)((UINT8 *)DmarStructHeader + DmarStructHeader->Length);
+    // MU_CHANGE TCBZ3768: BEGIN - DMAR structure length calculation in TestPointCheckLib is invalid
     DmarLen         -= DmarStructHeader->Length;
+    DmarStructHeader = (EFI_ACPI_DMAR_STRUCTURE_HEADER *)((UINT8 *)DmarStructHeader + DmarStructHeader->Length);
+    // MU_CHANGE TCBZ3768: END - DMAR structure length calculation in TestPointCheckLib is invalid
   }
 
   return EFI_SUCCESS;


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3768

When processing DMAR structures of type
EFI_ACPI_DMAR_STRUCTURE_HEADER within the ACPI DMAR table, the code
determines the structure length by subtracting the DMAR structure
headers present from the overall DMAR ACPI table size.

The terminating condition is that the remaining total DMAR length
is greater than zero. However, the current DMAR structure length
is subtracted after the DMAR structure pointer has already been
assigned to the next structure.

This change subtracts the current DMAR structure length before
transitioning to the next structure.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Eric Dong <eric.dong@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
(cherry picked from commit a5f8b98750f0df3b8b25bf5306514fab5ad24f74)