### PR TITLE
MinPlatform/TestPointCheckLib: Fix incorrect modification of MemoryTypeInformation HOB and memory leak

### DIFF
--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckMemoryMap.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckMemoryMap.c
@@ -73,7 +73,7 @@ TestPointDumpMemoryMap (
   ZeroMem (Pages, sizeof(Pages));
 
   DEBUG ((EFI_D_INFO, "MemoryMap:\n"));
-  
+
   Entry = MemoryMap;
   NumberOfEntries = MemoryMapSize / DescriptorSize;
   DEBUG ((DEBUG_INFO, "Type       Start            End              # Pages          Attributes\n"));
@@ -135,7 +135,7 @@ TestPointCheckUefiMemoryMapEntry (
     DEBUG ((DEBUG_ERROR, "EfiRuntimeServicesCode entry - %d\n", EntryCount[EfiRuntimeServicesCode]));
   }
   if (EntryCount[EfiRuntimeServicesData] > 1) {
-    DEBUG ((DEBUG_ERROR, "EfiRuntimeServicesData entry - %d\n", EntryCount[EfiRuntimeServicesCode]));
+    DEBUG ((DEBUG_ERROR, "EfiRuntimeServicesData entry - %d\n", EntryCount[EfiRuntimeServicesData]));
   }
   if (EntryCount[EfiACPIMemoryNVS] > 1) {
     DEBUG ((DEBUG_ERROR, "EfiACPIMemoryNVS entry - %d\n", EntryCount[EfiACPIMemoryNVS]));
@@ -167,13 +167,13 @@ TestPointDumpUefiMemoryMap (
   EFI_MEMORY_DESCRIPTOR *MemoryMap;
   UINTN                 MemoryMapSize;
   UINTN                 DescriptorSize;
-  
+
   if (UefiMemoryMap != NULL) {
     *UefiMemoryMap = NULL;
     *UefiMemoryMapSize = 0;
     *UefiDescriptorSize = 0;
   }
-  
+
   if (DumpPrint) {
     DEBUG ((DEBUG_INFO, "==== TestPointDumpUefiMemoryMap - Enter\n"));
   }
@@ -211,7 +211,7 @@ TestPointDumpUefiMemoryMap (
   if (MemoryMap == NULL) {
     goto Done ;
   }
-  
+
   if (DumpPrint) {
     TestPointDumpMemoryMap (MemoryMap, MemoryMapSize, DescriptorSize);
   }
@@ -242,7 +242,7 @@ TestPointCheckUefiMemoryMap (
   UINTN                 UefiMemoryMapSize;
   UINTN                 UefiDescriptorSize;
   BOOLEAN               Result;
-  
+
   DEBUG ((DEBUG_INFO, "==== TestPointCheckUefiMemoryMap - Enter\n"));
   UefiMemoryMapSize = 0;
   MemoryMap = NULL;

--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckMemoryTypeInformation.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckMemoryTypeInformation.c
@@ -16,26 +16,26 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/MemoryTypeInformation.h>
 
 CHAR8 *
-ShortNameOfMemoryType(
+ShortNameOfMemoryType (
   IN UINT32 Type
   );
 
 VOID
 DumpMemoryTypeInfoSummary (
-  IN EFI_MEMORY_TYPE_INFORMATION *CurrentMemoryTypeInformation,
-  IN EFI_MEMORY_TYPE_INFORMATION *PreviousMemoryTypeInformation
+  IN CONST EFI_MEMORY_TYPE_INFORMATION *CurrentMemoryTypeInformation,
+  IN CONST EFI_MEMORY_TYPE_INFORMATION *PreviousMemoryTypeInformation
   )
 {
-  UINTN                        Index;
-  UINTN                        Index1;
-  EFI_BOOT_MODE                BootMode;
-  UINT32                       Previous;
-  UINT32                       Current;
-  UINT32                       Next;
-  BOOLEAN                      MemoryTypeInformationModified;
+  UINTN          Index;
+  UINTN          Index1;
+  EFI_BOOT_MODE  BootMode;
+  UINT32         Previous;
+  UINT32         Current;
+  UINT32         Next;
+  BOOLEAN        MemoryTypeInformationModified;
 
   MemoryTypeInformationModified = FALSE;
-  BootMode = GetBootModeHob();
+  BootMode = GetBootModeHob ();
 
   //
   // Use a heuristic to adjust the Memory Type Information for the next boot
@@ -47,12 +47,12 @@ DumpMemoryTypeInfoSummary (
   DEBUG ((DEBUG_INFO, "==========  ========  ========  ========\n"));
 
   for (Index = 0; PreviousMemoryTypeInformation[Index].Type != EfiMaxMemoryType; Index++) {
-
     for (Index1 = 0; CurrentMemoryTypeInformation[Index1].Type != EfiMaxMemoryType; Index1++) {
       if (PreviousMemoryTypeInformation[Index].Type == CurrentMemoryTypeInformation[Index1].Type) {
         break;
       }
     }
+
     if (CurrentMemoryTypeInformation[Index1].Type == EfiMaxMemoryType) {
       continue;
     }
@@ -62,12 +62,12 @@ DumpMemoryTypeInfoSummary (
     // Current is the number of pages actually needed
     //
     Previous = PreviousMemoryTypeInformation[Index].NumberOfPages;
-    Current = CurrentMemoryTypeInformation[Index1].NumberOfPages;
-    Next = Previous;
+    Current  = CurrentMemoryTypeInformation[Index1].NumberOfPages;
+    Next     = Previous;
 
     //
     // Inconsistent Memory Reserved across bootings may lead to S4 fail
-    // Write next varible to 125% * current when the pre-allocated memory is:
+    // Write next variable to 125% * current when the pre-allocated memory is:
     //  1. More than 150% of needed memory and boot mode is BOOT_WITH_DEFAULT_SETTING
     //  2. Less than the needed memory
     //
@@ -78,18 +78,19 @@ DumpMemoryTypeInfoSummary (
     } else if (Current > Previous) {
       Next = Current + (Current >> 2);
     }
-    if (Next > 0 && Next < 4) {
+
+    if ((Next > 0) && (Next < 4)) {
       Next = 4;
     }
 
     if (Next != Previous) {
-      PreviousMemoryTypeInformation[Index].NumberOfPages = Next;
       MemoryTypeInformationModified = TRUE;
     }
 
-    DEBUG ((DEBUG_INFO, ShortNameOfMemoryType(PreviousMemoryTypeInformation[Index].Type)));
+    DEBUG ((DEBUG_INFO, ShortNameOfMemoryType (PreviousMemoryTypeInformation[Index].Type)));
     DEBUG ((DEBUG_INFO, "  %08x  %08x  %08x\n", Previous, Current, Next));
   }
+
   DEBUG ((DEBUG_INFO, "\n"));
 
   if (MemoryTypeInformationModified) {
@@ -97,6 +98,7 @@ DumpMemoryTypeInfoSummary (
   } else {
     DEBUG ((DEBUG_INFO, "MemoryTypeInformation - Unmodified.\n"));
   }
+
   DEBUG ((DEBUG_INFO, "\n"));
 }
 
@@ -105,50 +107,44 @@ TestPointCheckMemoryTypeInformation (
   VOID
   )
 {
-  EFI_STATUS              Status;
-  EFI_HOB_GUID_TYPE       *GuidHob;
-  VOID                    *CurrentMemoryTypeInformation;
-  VOID                    *PreviousMemoryTypeInformation;
-  VOID                    *VariableMemoryTypeInformation;
-  
+  EFI_STATUS         Status;
+  EFI_HOB_GUID_TYPE  *GuidHob;
+  VOID               *CurrentMemoryTypeInformation;
+  VOID               *PreviousMemoryTypeInformation;
+
   DEBUG ((DEBUG_INFO, "==== TestPointCheckMemoryTypeInformation - Enter\n"));
-  CurrentMemoryTypeInformation = NULL;
+  CurrentMemoryTypeInformation  = NULL;
   PreviousMemoryTypeInformation = NULL;
 
   Status = EfiGetSystemConfigurationTable (&gEfiMemoryTypeInformationGuid, &CurrentMemoryTypeInformation);
-  if (EFI_ERROR(Status)) {
+  if (EFI_ERROR (Status)) {
     goto Done;
   }
 
   GuidHob = GetFirstGuidHob (&gEfiMemoryTypeInformationGuid);
   if (GuidHob != NULL) {
-    PreviousMemoryTypeInformation = GET_GUID_HOB_DATA(GuidHob);
+    PreviousMemoryTypeInformation = GET_GUID_HOB_DATA (GuidHob);
   } else {
     Status = EFI_NOT_FOUND;
     goto Done;
   }
 
-  GetVariable2 (
-             EFI_MEMORY_TYPE_INFORMATION_VARIABLE_NAME,
-             &gEfiMemoryTypeInformationGuid,
-             &VariableMemoryTypeInformation,
-             NULL
-             );
-
   if ((CurrentMemoryTypeInformation != NULL) && (PreviousMemoryTypeInformation != NULL)) {
-    DumpMemoryTypeInfoSummary(CurrentMemoryTypeInformation, PreviousMemoryTypeInformation);
+    DumpMemoryTypeInfoSummary (CurrentMemoryTypeInformation, PreviousMemoryTypeInformation);
   }
+
   DEBUG ((DEBUG_INFO, "==== TestPointCheckMemoryTypeInformation - Exit\n"));
 
 Done:
-  if (EFI_ERROR(Status)) {
+  if (EFI_ERROR (Status)) {
     TestPointLibAppendErrorString (
       PLATFORM_TEST_POINT_ROLE_PLATFORM_IBV,
       NULL,
       TEST_POINT_BYTE4_READY_TO_BOOT_MEMORY_TYPE_INFORMATION_FUNCTIONAL_ERROR_CODE \
-        TEST_POINT_READY_TO_BOOT \
-        TEST_POINT_BYTE4_READY_TO_BOOT_MEMORY_TYPE_INFORMATION_FUNCTIONAL_ERROR_STRING
+      TEST_POINT_READY_TO_BOOT \
+      TEST_POINT_BYTE4_READY_TO_BOOT_MEMORY_TYPE_INFORMATION_FUNCTIONAL_ERROR_STRING
       );
   }
+
   return Status;
 }


### PR DESCRIPTION
DxeCheckMemoryTypeInformation - 
fix an issue where MemoryTYpeInfo check was incorectly modifying the MemoryTypeInformation HOB which broke logic in subsequent consumers. Removed a spurious allocation that was unused and never freed. Cleaned up coding style to match ECC.

DxeCheckMemoryMap - 
fixed an incorrect index that lead to wrong information display