### PR TITLE
MinPlatformPkg/SmmMultiBoardAcpiSupportLib: Use MmServicesTableLib

### DIFF
--- a/MinPlatformPkg/Acpi/Library/MultiBoardAcpiSupportLib/SmmMultiBoardAcpiSupportLib.c
+++ b/MinPlatformPkg/Acpi/Library/MultiBoardAcpiSupportLib/SmmMultiBoardAcpiSupportLib.c
@@ -8,7 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/BoardAcpiEnableLib.h>
 #include <Library/MultiBoardAcpiSupportLib.h>
 #include <Library/DebugLib.h>
-#include <Library/SmmServicesTableLib.h>
+#include <Library/MmServicesTableLib.h>
 
 EFI_STATUS
 EFIAPI

--- a/MinPlatformPkg/Acpi/Library/MultiBoardAcpiSupportLib/SmmMultiBoardAcpiSupportLib.inf
+++ b/MinPlatformPkg/Acpi/Library/MultiBoardAcpiSupportLib/SmmMultiBoardAcpiSupportLib.inf
@@ -20,7 +20,7 @@
   BaseLib
   PcdLib
   DebugLib
-  SmmServicesTableLib
+  MmServicesTableLib
 
 [Packages]
   MinPlatformPkg/MinPlatformPkg.dec
@@ -29,7 +29,7 @@
 [Sources]
   SmmMultiBoardAcpiSupportLib.c
   SmmBoardAcpiEnableLib.c
-  
+
 [Guids]
   gBoardAcpiEnableGuid
 


### PR DESCRIPTION
The code currently references 'gMmst' which is in MmServicesTable but
it links against SmmServicesTableLib which contains 'gSmst'.