### PR TITLE
CHERRY_PICK: MinPlatformPkg/TestPointCheckLib: Make OutTable parameter optional

### DIFF
--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckAcpi.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckAcpi.c
@@ -477,7 +477,7 @@ DumpAcpiTable (
   )
 {
   EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE  *Fadt;
-  
+
   if (Table == NULL) {
     return ;
   }
@@ -535,7 +535,7 @@ CheckAcpiTableResource (
   )
 {
   EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE  *Fadt;
-  
+
   if (Table == NULL) {
     return EFI_INVALID_PARAMETER;
   }
@@ -592,7 +592,7 @@ EFI_STATUS
 DumpAcpiRsdt (
   IN EFI_ACPI_DESCRIPTION_HEADER  *Rsdt,
   IN UINT32                       *Signature, OPTIONAL
-  OUT VOID                        **OutTable,
+  OUT VOID                        **OutTable, OPTIONAL // MS_CHANGE_2154918
   IN BOOLEAN                      DumpPrint,
   IN BOOLEAN                      CheckResource
   )
@@ -610,7 +610,9 @@ DumpAcpiRsdt (
 
   if (OutTable != NULL) {
     *OutTable = NULL;
-  } else {
+  } else if ((OutTable == NULL) && // MS_CHANGE_2154918
+             (Signature != NULL))
+  {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -632,7 +634,7 @@ DumpAcpiRsdt (
       *OutTable = Table;
     }
   }
-  
+
   if (OutTable != NULL) {
     if (*OutTable == NULL) {
       return EFI_NOT_FOUND;
@@ -646,7 +648,7 @@ EFI_STATUS
 DumpAcpiXsdt (
   IN EFI_ACPI_DESCRIPTION_HEADER  *Xsdt,
   IN UINT32                       *Signature, OPTIONAL
-  OUT VOID                        **OutTable,
+  OUT VOID                        **OutTable, OPTIONAL // MS_CHANGE_2154918
   IN BOOLEAN                      DumpPrint,
   IN BOOLEAN                      CheckResource
   )
@@ -662,16 +664,18 @@ DumpAcpiXsdt (
   if (Xsdt == NULL) {
     return EFI_INVALID_PARAMETER;
   }
-  
+
   if (OutTable != NULL) {
     *OutTable = NULL;
-  } else {
+  } else if ((OutTable == NULL) && // MS_CHANGE_2154918
+             (Signature != NULL))
+  {
     return EFI_INVALID_PARAMETER;
   }
 
   ReturnStatus = EFI_SUCCESS;
   EntryCount = (Xsdt->Length - sizeof (EFI_ACPI_DESCRIPTION_HEADER)) / sizeof(UINT64);
-  
+
   BasePtr = (UINTN)(Xsdt + 1);
   for (Index = 0; Index < EntryCount; Index ++) {
     CopyMem (&EntryPtr, (VOID *)(BasePtr + Index * sizeof(UINT64)), sizeof(UINT64));
@@ -783,7 +787,7 @@ TestPointCheckAcpi (
   if (Status == EFI_NOT_FOUND) {
     Status = DumpAcpiWithGuid (&gEfiAcpi10TableGuid, NULL, NULL, TRUE, FALSE);
   }
-  
+
   if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR, "No ACPI table\n"));
     TestPointLibAppendErrorString (
@@ -796,7 +800,7 @@ TestPointCheckAcpi (
   }
 
   DEBUG ((DEBUG_INFO, "==== TestPointCheckAcpi - Exit\n"));
-  
+
   return Status;
 }
 
@@ -806,9 +810,9 @@ TestPointCheckAcpiGcdResource (
   )
 {
   EFI_STATUS  Status;
-  
+
   DEBUG ((DEBUG_INFO, "==== TestPointCheckAcpiGcdResource - Enter\n"));
-  
+
   //
   // Check the ACPI existence
   //
@@ -816,7 +820,7 @@ TestPointCheckAcpiGcdResource (
   if (Status == EFI_NOT_FOUND) {
     Status = DumpAcpiWithGuid (&gEfiAcpi10TableGuid, NULL, NULL, FALSE, FALSE);
   }
-  
+
   if (!EFI_ERROR(Status)) {
     //
     // Then check resource in ACPI and GCD
@@ -828,7 +832,7 @@ TestPointCheckAcpiGcdResource (
       Status = DumpAcpiWithGuid (&gEfiAcpi10TableGuid, NULL, NULL, FALSE, TRUE);
     }
   }
-  
+
   if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR, "ACPI table resource not in GCD\n"));
     TestPointLibAppendErrorString (
@@ -840,7 +844,7 @@ TestPointCheckAcpiGcdResource (
       );
   }
   DEBUG ((DEBUG_INFO, "==== TestPointCheckAcpiGcdResource - Exit\n"));
-  
+
   return Status;
 }
 


### PR DESCRIPTION
Makes the OutTable parameter in DumpAcpiRsdt() and DumpAcpiXsdt()
optional since the pointer passed can be NULL if the Signature
pointer is also NULL.

Can fix a potential failure in TestPointCheckAcpi().

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Eric Dong <eric.dong@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Nate DeSimone <nathaniel.l.desimone@intel.com>
(cherry picked from commit 89fb75a)