### PR TITLE
CHERRY_PICK: MinPlatformPkg/SmmMultiBoardAcpiSupportLib: Use MmServicesTableLib

### DIFF
--- a/MinPlatformPkg/Acpi/Library/MultiBoardAcpiSupportLib/SmmMultiBoardAcpiSupportLib.c
+++ b/MinPlatformPkg/Acpi/Library/MultiBoardAcpiSupportLib/SmmMultiBoardAcpiSupportLib.c
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MultiBoardAcpiSupportLib.h>
 #include <Library/PcdLib.h>
 #include <Library/DebugLib.h>
-#include <Library/SmmServicesTableLib.h>
+#include <Library/MmServicesTableLib.h>
 
 EFI_STATUS
 EFIAPI
@@ -21,7 +21,7 @@ RegisterBoardAcpiEnableFunc (
   EFI_STATUS  Status;
 
   Handle = NULL;
-  Status = gSmst->SmmInstallProtocolInterface (
+  Status = gMmst->MmInstallProtocolInterface (
                     &Handle,
                     &gBoardAcpiEnableGuid,
                     EFI_NATIVE_INTERFACE,

--- a/MinPlatformPkg/Acpi/Library/MultiBoardAcpiSupportLib/SmmMultiBoardAcpiSupportLib.inf
+++ b/MinPlatformPkg/Acpi/Library/MultiBoardAcpiSupportLib/SmmMultiBoardAcpiSupportLib.inf
@@ -20,7 +20,7 @@
   BaseLib
   PcdLib
   DebugLib
-  SmmServicesTableLib
+  MmServicesTableLib
 
 [Packages]
   MinPlatformPkg/MinPlatformPkg.dec
@@ -29,7 +29,7 @@
 [Sources]
   SmmMultiBoardAcpiSupportLib.c
   SmmBoardAcpiEnableLib.c
-  
+
 [Guids]
   gBoardAcpiEnableGuid
 


### PR DESCRIPTION
The code currently references 'gMmst' which is in MmServicesTable but
it links against SmmServicesTableLib which contains 'gSmst'.

(cherry picked from commit 3fb16af)