### PR TITLE
Switch from VS2019 to VS2022

### DIFF
--- a/.azurepipelines/Windows-VS2022.yml
+++ b/.azurepipelines/Windows-VS2022.yml
@@ -1,5 +1,5 @@
 ## @file
-# Azure Pipeline build file for a build using Windows and VS2019
+# Azure Pipeline build file for a build using Windows and VS2022
 #
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -26,6 +26,6 @@ pr:
 jobs:
 - template: templates/pr-gate-build-job.yml
   parameters:
-    tool_chain_tag: 'VS2019'
-    vm_image: 'windows-latest'
+    tool_chain_tag: 'VS2022'
+    vm_image: 'windows-2022'
     arch_list: "IA32,X64"

--- a/.azurepipelines/templates/markdownlint-check-prereq-steps.yml
+++ b/.azurepipelines/templates/markdownlint-check-prereq-steps.yml
@@ -13,6 +13,6 @@ parameters:
 
 steps:
 
-- script: npm install -g markdownlint-cli@0.31.0
+- script: npm install -g markdownlint-cli@0.31.1
   displayName: "Install markdown linter"
   condition: and(gt(variables.pkg_count, 0), succeeded())

--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -20,7 +20,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.10.x'    # MU_CHANGE
+    versionSpec: '3.8.x'    # MU_CHANGE
     architecture: 'x64'
 
 - script: pip install -r pip-requirements.txt --upgrade

--- a/.azurepipelines/templates/spell-check-prereq-steps.yml
+++ b/.azurepipelines/templates/spell-check-prereq-steps.yml
@@ -17,6 +17,6 @@ steps:
     #checkLatest: false # Optional
   condition: and(gt(variables.pkg_count, 0), succeeded())
 
-- script: npm install -g cspell@5.18.4
+- script: npm install -g cspell@5.19.2
   displayName: 'Install cspell npm'
   condition: and(gt(variables.pkg_count, 0), succeeded())

--- a/ReadMe.rst
+++ b/ReadMe.rst
@@ -5,7 +5,7 @@ Project Mu Intel Common MinPlatform Repo
 ============================= ================= =============== ===================
  Host Type & Toolchain        Build Status      Test Status     Code Coverage
 ============================= ================= =============== ===================
-Windows_VS2019_               |WindowsCiBuild|  |WindowsCiTest| |WindowsCiCoverage|
+Windows_VS2022_               |WindowsCiBuild|  |WindowsCiTest| |WindowsCiCoverage|
 Ubuntu_GCC5_                  |UbuntuCiBuild|   |UbuntuCiTest|  |UbuntuCiCoverage|
 ============================= ================= =============== ===================
 
@@ -60,7 +60,7 @@ Bug Fixes-dev
 
 | Starting commit: 1584a46f ("Updated references to Tcg libraries to use MU_TIANO_PLUS library that was moved out of this repo", 2022-02-15)
 | Destination commit: 7e07c136 ("MinPlatformPkg/SaveMemoryConfig: Fix GCC build failure.", 2022-02-17)
-  
+
   Needed to cherry-pick changes from 2102 branch that were left out of 2111
   - Removed TCBZ3033 added in upstream and reverted locally
   - Cherry-picked 53dcee339d TCBZ3612 MinPlatformPkg/Test: Fix mis-parsed HSTI structures (#13) from 202102 release
@@ -178,8 +178,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 .. CoreCI
 
-.. _Windows_VS2019: https://dev.azure.com/projectmu/mu/_build/latest?definitionId=71&&branchName=release%2F202202
-.. |WindowsCiBuild| image:: https://dev.azure.com/projectmu/mu/_apis/build/status/CI/Mu%20Common%20Intel%20MinPlatform%20CI%20VS2019?branchName=release%2F202202
+.. _Windows_VS2022: https://dev.azure.com/projectmu/mu/_build/latest?definitionId=71&&branchName=release%2F202202
+.. |WindowsCiBuild| image:: https://dev.azure.com/projectmu/mu/_apis/build/status/CI/Mu%20Common%20Intel%20MinPlatform%20CI%20VS2022?branchName=release%2F202202
 .. |WindowsCiTest| image:: https://img.shields.io/azure-devops/tests/projectmu/mu/71.svg
 .. |WindowsCiCoverage| image:: https://img.shields.io/badge/coverage-coming_soon-blue
 

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.11.0 # MU_CHANGE - update to 0.11.0 or later
-edk2-pytool-extensions~=0.16.0 # MU_CHANGE - update to 0.16.0 or later
+edk2-pytool-library~=0.11.2 # MU_CHANGE - update to 0.11.2 or later
+edk2-pytool-extensions~=0.17.0 # MU_CHANGE - update to 0.17.0 or later
 edk2-basetools==0.1.13 # MU_CHANGE - update to 0.1.13 or later
 antlr4-python3-runtime==4.7.1


### PR DESCRIPTION
Updates:
1. VS Compiler to "VS2022"
2. Windows VM image to "windows-2022"
3. edk2-pytool-extensions to "0.17.0"
4. edk2-pytool-library to "0.11.2"
5. markdownlint to "0.31.1"
6. cspell to "5.19.2"