### PR TITLE
Handle scenarios around transitioning to this implementation from older implementations

### DIFF
--- a/MinPlatformPkg/FspWrapper/SaveMemoryConfig/SaveMemoryConfig.c
+++ b/MinPlatformPkg/FspWrapper/SaveMemoryConfig/SaveMemoryConfig.c
@@ -22,6 +22,32 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/VariableWriteLib.h>
 #include <Guid/FspNonVolatileStorageHob2.h>
 
+//MU_CHANGE - Remove variables created by previous versions of this driver.
+/**
+  Remove variables created by previous versions of this driver.
+
+  @retval    None - errors are handled internally to the function.
+**/
+VOID
+DeleteObsoleteVariables (
+  VOID
+  )
+{
+  EFI_STATUS Status;
+  UINTN      BufferSize;
+
+  BufferSize = 0;
+  Status = GetLargeVariable(L"MemoryConfig", &gFspNonVolatileStorageHobGuid, &BufferSize, NULL);
+  if (Status == EFI_BUFFER_TOO_SMALL) {
+    //Old variable exists; remove it.
+    Status = SetLargeVariable(L"MemoryConfig", &gFspNonVolatileStorageHobGuid, FALSE, 0, NULL);
+    ASSERT_EFI_ERROR (Status); // Error here is unexpected but non-fatal, assert for debug.
+  } else if (Status != EFI_NOT_FOUND) {
+    ASSERT_EFI_ERROR (Status); // Error status other than EFI_NOT_FOUND is unexpected but non-fatal, assert for debug.
+  }
+}
+//MU_CHANGE - End
+
 /**
   This is the standard EFI driver point that detects whether there is a
   MemoryConfigurationData HOB and, if so, saves its data to nvRAM.
@@ -52,6 +78,8 @@ SaveMemoryConfigEntryPoint (
   GuidHob         = NULL;
   HobData         = NULL;
   DataIsIdentical = FALSE;
+
+  DeleteObsoleteVariables (); //MU_CHANGE: attempt to remove variables created by previous versions of this driver.
 
   //
   // Search for the Memory Configuration GUID HOB.  If it is not present, then
@@ -113,6 +141,13 @@ SaveMemoryConfigEntryPoint (
       Status = EFI_SUCCESS;
 
       if (!DataIsIdentical) {
+        //MU_CHANGE: Delete the variable first to allow reclaim of its space for the new version if needed.
+        Status = SetLargeVariable (L"FspNvsBuffer", &gFspNvsBufferVariableGuid, FALSE, 0, NULL);
+        // Delete failure is unexpected, so assert; but proceed to attempt SetVariable anyway if failure occurs in
+        // a build without ASSERT_EFI_ERROR hang.
+        ASSERT_EFI_ERROR (Status);
+        //MU_CHANGE: End
+
         Status = SetLargeVariable (L"FspNvsBuffer", &gFspNvsBufferVariableGuid, TRUE, DataSize, HobData);
         if (Status == EFI_ABORTED) {
           //

--- a/MinPlatformPkg/FspWrapper/SaveMemoryConfig/SaveMemoryConfig.c
+++ b/MinPlatformPkg/FspWrapper/SaveMemoryConfig/SaveMemoryConfig.c
@@ -81,7 +81,7 @@ SaveMemoryConfigEntryPoint (
 
   DeleteObsoleteVariables (); //MU_CHANGE: attempt to remove variables created by previous versions of this driver.
 
-//.
+  //
   // Search for the Memory Configuration GUID HOB.  If it is not present, then
   // there's nothing we can do. It may not exist on the update path.
   // Firstly check version2 FspNvsHob.
@@ -145,7 +145,9 @@ SaveMemoryConfigEntryPoint (
         Status = SetLargeVariable (L"FspNvsBuffer", &gFspNvsBufferVariableGuid, FALSE, 0, NULL);
         // Delete failure is unexpected, so assert; but proceed to attempt SetVariable anyway if failure occurs in
         // a build without ASSERT_EFI_ERROR hang.
-        ASSERT_EFI_ERROR (Status);
+        if (EFI_ERROR (Status) && (Status != EFI_NOT_FOUND)) {
+          ASSERT_EFI_ERROR (Status);
+        }
         //MU_CHANGE: End
 
         Status = SetLargeVariable (L"FspNvsBuffer", &gFspNvsBufferVariableGuid, TRUE, DataSize, HobData);

--- a/MinPlatformPkg/FspWrapper/SaveMemoryConfig/SaveMemoryConfig.c
+++ b/MinPlatformPkg/FspWrapper/SaveMemoryConfig/SaveMemoryConfig.c
@@ -81,7 +81,7 @@ SaveMemoryConfigEntryPoint (
 
   DeleteObsoleteVariables (); //MU_CHANGE: attempt to remove variables created by previous versions of this driver.
 
-  //
+//.
   // Search for the Memory Configuration GUID HOB.  If it is not present, then
   // there's nothing we can do. It may not exist on the update path.
   // Firstly check version2 FspNvsHob.

--- a/MinPlatformPkg/Library/BaseLargeVariableLib/LargeVariableWriteLib.c
+++ b/MinPlatformPkg/Library/BaseLargeVariableLib/LargeVariableWriteLib.c
@@ -163,7 +163,8 @@ DeleteLargeVariableInternal (
     Status = VarLibSetVariable (
                 VariableName,
                 VendorGuid,
-                EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS,
+                //EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS, //MU_CHANGE
+                0, //MU_CHANGE - use zero attribute when deleting a variable.
                 0,
                 NULL
                 );
@@ -198,7 +199,8 @@ DeleteLargeVariableInternal (
         Status2 = VarLibSetVariable (
                     TempVariableName,
                     VendorGuid,
-                    EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS,
+                    //EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS, //MU_CHANGE
+                    0, //MU_CHANGE - use zero attribute when deleting a variable.
                     0,
                     NULL
                     );


### PR DESCRIPTION
Older implementations used L"MemoryConfig" as the variable name. When transitioning to this implementation, they would leave behind large variables that were obsolete. This PR adds a change to remove the obsolete variable if it exist. 

In addition, when saving a new set of FSP nv data, the old data is explicitly deleted first. This allows it to be reclaimed if needed to free up space when saving the new data. 