### PR TITLE
Add support for minimum allocation HOB for memory types. 

### DIFF
--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
@@ -199,6 +199,17 @@ BuildMemoryTypeInformation (
     MemoryData,
     DataSize
     );
+
+  //MU_CHANGE - Add minimum memory type allocations
+  //
+  // Publish default memory types as minimum allocations.
+  //
+  BuildGuidDataHob (
+    &gEfiMemoryTypeMinimumAllocationGuid,
+    mDefaultMemoryTypeInformation,
+    sizeof (mDefaultMemoryTypeInformation)
+    );
+  //MU_CHANGE - END
 }
 
 EFI_STATUS

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.inf
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.inf
@@ -63,6 +63,7 @@
 
 [Guids]
   gEfiMemoryTypeInformationGuid
+  gEfiMemoryTypeMinimumAllocationGuid  #MU_CHANGE - Add minimum memory type allocations
 
 [Depex]
   gEfiPeiReadOnlyVariable2PpiGuid

--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeTestPointCheckLib.inf
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeTestPointCheckLib.inf
@@ -79,6 +79,7 @@
   gEfiAcpi20TableGuid
   gEfiAcpi10TableGuid
   gEfiMemoryTypeInformationGuid
+  gEfiMemoryTypeMinimumAllocationGuid  #MU_CHANGE - Add minimum memory type allocations
   gEfiSystemResourceTableGuid
   gEfiMemoryOverwriteControlDataGuid
   gEfiMemoryOverwriteRequestControlLockGuid


### PR DESCRIPTION
This PR adds support for publishing a minimum allocation HOB for memory types.
The platform-specified memory type info PCDs is used to populate the HOB (if they are present).

In addition, the DxeCheckMemoryTypeInfo test is updated to support minimum allocation HOB.