### PR TITLE
Add TestPointPciEnumerationDonePcieGenSpeed to TestPointCheckLibNull.c

### DIFF
--- a/MinPlatformPkg/Test/Library/TestPointCheckLibNull/TestPointCheckLibNull.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLibNull/TestPointCheckLibNull.c
@@ -723,3 +723,17 @@ TestPointSmmExitBootServices (
 {
   return EFI_SUCCESS;
 }
+
+/**
+ Test that required devices have trained to the required link speed.
+
+ @retval EFI_SUCCESS         Test was performed and flagged as verified or error logged.
+**/
+EFI_STATUS
+EFIAPI
+TestPointPciEnumerationDonePcieGenSpeed (
+  VOID
+  )
+{
+  return EFI_SUCCESS;
+}


### PR DESCRIPTION
Description:
To avoid potential build breaks in the consuming repositories, add TestPointPciEnumerationDonePcieGenSpeed () to TestPointCheckLibNull.c

How Tested:
Verified that previously failing builds now succeed.