### PR TITLE
[CHERRY-PICK] MinPlatformPkg/TestPointCheckLib: Fix out of bounds array index access

### DIFF
--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckPci.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckPci.c
@@ -86,7 +86,7 @@ DumpPciDevice (
     PciData->Device.Bar[2],
     PciData->Device.Bar[3],
     PciData->Device.Bar[4],
-    PciData->Device.Bar[6]
+    PciData->Device.Bar[5]
     ));
   DEBUG ((DEBUG_INFO, " %04x\n",
     PciData->Hdr.Command


### PR DESCRIPTION
The following code accesses array index "6" which is invalid as the array is of length 6.

  DEBUG ((DEBUG_INFO, " %08x %08x %08x %08x %08x %08x",
    PciData->Device.Bar[0],
    PciData->Device.Bar[1],
    PciData->Device.Bar[2],
    PciData->Device.Bar[3],
    PciData->Device.Bar[4],
    PciData->Device.Bar[6]   <-- BAD ARRAY INDEX
    ));

PciData is of type "PCI_TYPE00":

  typedef struct {
    PCI_DEVICE_INDEPENDENT_REGION    Hdr;
    PCI_DEVICE_HEADER_TYPE_REGION    Device;
  } PCI_TYPE00;

"PCI_DEVICE_HEADER_TYPE_REGION":

typedef struct {
  UINT32    Bar[6];          <- NOTE: ARRAY LENGTH IS 6
  UINT32    CISPtr;
  UINT16    SubsystemVendorID;
  UINT16    SubsystemID;
  UINT32    ExpansionRomBar;
  UINT8     CapabilityPtr;
  UINT8     Reserved1[3];
  UINT32    Reserved2;
  UINT8     InterruptLine;
  UINT8     InterruptPin;
  UINT8     MinGnt;
  UINT8     MaxLat;
} PCI_DEVICE_HEADER_TYPE_REGION;

This change fixes the array index value.

Cc: Chasel Chiu <chasel.chiu@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Eric Dong <eric.dong@intel.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Isaac Oram <isaac.w.oram@intel.com>
(cherry picked from commit 7f63ab7da9001a550c8d7e8db4811022301b43b8)