### PR TITLE
 MinPlatformPkg: Ignore line endings

### DIFF
--- a/MinPlatformPkg/MinPlatformPkg.ci.yaml
+++ b/MinPlatformPkg/MinPlatformPkg.ci.yaml
@@ -103,5 +103,10 @@
     ## options defined .pytool/Plugin/UncrustifyCheck
     "UncrustifyCheck": {
         "AuditOnly": True,
+    },
+
+    ## options defined .pytool/Plugin/LineEndingCheck
+    "LineEndingCheck": {
+        "IgnoreFiles": ["**/*"]   # Ignore all line endings to prevent non-visible merge delta from upstream
     }
 }


### PR DESCRIPTION
Ignores line ending check for all files in MinPlatformPkg to
prevent unnecessary non-visible whitespace delta from upstream.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>