### PR TITLE
Add logic for container build to Matrix-Build-Job.yml

### DIFF
--- a/.azurepipelines/Matrix-Build-Job.yml
+++ b/.azurepipelines/Matrix-Build-Job.yml
@@ -29,6 +29,10 @@ parameters:
   displayName: Virtual Machine Image (e.g. windows-latest)
   type: string
   default: 'windows-latest'
+- name: container_image
+  displayName: Container Image
+  type: string
+  default: ''
 
 jobs:
 
@@ -44,10 +48,16 @@ jobs:
   workspace:
     clean: all
 
+  ${{ if ne(parameters.container_image, '') }}:
+    container: ${{ parameters.container_image }} 
+
   pool:
     vmImage: ${{ parameters.vm_image }}
 
   steps:
+  - ${{ if and(ne(parameters.container_image, ''), not(contains(parameters.vm_image, 'windows'))) }}:
+    - script: echo "##vso[task.prependpath]/home/vsts_azpcontainer/.local/bin"
+      displayName: Add User Local Bin to Path
   - template: Steps/PrGate.yml@mu_devops
     parameters:
       build_archs: ${{ parameters.arch_list }}

--- a/.azurepipelines/Matrix-Build-Job.yml
+++ b/.azurepipelines/Matrix-Build-Job.yml
@@ -71,3 +71,4 @@ jobs:
       extra_build_args: ${{ parameters.extra_build_args }}
       extra_install_step: ${{ parameters.extra_install_step }}
       tool_chain_tag: ${{ parameters.tool_chain_tag }}
+      install_tools: ${{ eq(parameters.container_image, '') }}


### PR DESCRIPTION
## Description

Changes the matrix build job to be able to take input for the container image used in the generic mu_devops file generated. 

Will be used by: https://github.com/microsoft/mu_devops/pull/59 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on test pipeline with mu_devops changes made locally

## Integration Instructions

N/A