### PR TITLE
Added BoardModulePkg

### DIFF
--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -50,7 +50,8 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
         ''' return iterable of edk2 packages supported by this build.
         These should be edk2 workspace relative paths '''
 
-        return ("MinPlatformPkg", )
+        return ("MinPlatformPkg",
+                "BoardModulePkg" )
 
     def GetArchitecturesSupported(self):
         ''' return iterable of edk2 architectures supported by this build '''

--- a/BoardModulePkg/BoardModulePkg.ci.yaml
+++ b/BoardModulePkg/BoardModulePkg.ci.yaml
@@ -1,0 +1,104 @@
+## @file
+# CI configuration for BoardModulePkg
+#
+# Copyright (c) Microsoft Corporation
+# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+    ## options defined .pytool/Plugin/LicenseCheck
+    "LicenseCheck": {
+        "IgnoreFiles": []
+    },
+    "EccCheck": {
+        ## Exception sample looks like below:
+        ## "ExceptionList": [
+        ##     "<ErrorID>", "<KeyWord>"
+        ## ]
+        "ExceptionList": [
+        ],
+        ## Both file path and directory path are accepted.
+        "IgnoreFiles": [
+        ]
+    },
+    ## options defined .pytool/Plugin/CompilerPlugin
+    "CompilerPlugin": {
+        "DscPath": "BoardModulePkg.dsc"
+    },
+
+    ## options defined .pytool/Plugin/CharEncodingCheck
+    "CharEncodingCheck": {
+        "IgnoreFiles": [
+        ]
+    },
+
+    ## options defined .pytool/Plugin/DependencyCheck
+    "DependencyCheck": {
+        "AcceptableDependencies": [
+            "MdePkg/MdePkg.dec",
+            "MdeModulePkg/MdeModulePkg.dec",
+            "BoardModulePkg/BoardModulePkg.dec",
+        ],
+        # For host based unit tests
+        "AcceptableDependencies-HOST_APPLICATION":[
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
+        # For UEFI shell based apps
+        "AcceptableDependencies-UEFI_APPLICATION":[],
+        "IgnoreInf": []
+    },
+
+    ## options defined .pytool/Plugin/DscCompleteCheck
+    "DscCompleteCheck": {
+        "IgnoreInf": [
+        ],
+        "DscPath": "BoardModulePkg.dsc"
+    },
+
+    ## options defined .pytool/Plugin/GuidCheck
+    "GuidCheck": {
+        "IgnoreGuidName": [],
+        "IgnoreGuidValue": ["00000000-0000-0000-0000-000000000000"],
+        "IgnoreFoldersAndFiles": [],
+        "IgnoreDuplicates": [
+        ]
+    },
+
+    ## options defined .pytool/Plugin/LibraryClassCheck
+    "LibraryClassCheck": {
+        "IgnoreLibraryClass": [
+        ],
+        "IgnoreHeaderFile": []
+    },
+
+    ## options defined .pytool/Plugin/SpellCheck
+    "SpellCheck": {
+        "AuditOnly": True,           # Fails test but run in AuditOnly mode to collect log
+        "IgnoreStandardPaths": [     # Standard Plugin defined paths that should be ignore
+            "*.c", "*.asm", "*.h", "*.nasm", "*.s", "*.asl", "*.inf"
+        ],
+        "IgnoreFiles": [             # use gitignore syntax to ignore errors in matching files
+            ""
+        ],
+        "ExtendWords": [           # words to extend to the dictionary for this package
+        ],
+        "AdditionalIncludePaths": [] # Additional paths to spell check relative to package root (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "IgnoreFiles": [
+        ]            # package root relative file, folder, or glob pattern to ignore
+    },
+
+    ## Disabling uncrustify until edk2-platforms updates
+    ## options defined .pytool/Plugin/UncrustifyCheck
+    "UncrustifyCheck": {
+        "AuditOnly": True,
+    },
+
+    ## options defined .pytool/Plugin/LineEndingCheck
+    "LineEndingCheck": {
+        "IgnoreFiles": ["**/*"]   # Ignore all line endings to prevent non-visible merge delta from upstream
+    }
+}

--- a/BoardModulePkg/BoardModulePkg.dec
+++ b/BoardModulePkg/BoardModulePkg.dec
@@ -1,0 +1,47 @@
+## @file
+# This package provides the modules that build for a full feature platform.
+# This BoardModulePkg should only depend on EDKII Core packages and MinPlatformPkg.
+#
+# The DEC files are used by the utilities that parse DSC and
+# INF files to generate AutoGen.c and AutoGen.h files
+# for the build infrastructure.
+#
+# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+[Defines]
+  DEC_SPECIFICATION = 0x00010017
+  PACKAGE_NAME      = BoardModulePkg
+  PACKAGE_VERSION   = 0.1
+  PACKAGE_GUID      = 30EEB750-574D-45AA-8895-D77161019BC7
+
+
+[Includes]
+  Include
+
+[LibraryClasses]
+  ##  @libraryclass    Provide services to access CMOS area.
+  CmosAccessLib|Include/Library/CmosAccessLib.h
+
+  ##  @libraryclass    Provide platform relevant services to access CMOS area.
+  PlatformCmosAccessLib|Include/Library/PlatformCmosAccessLib.h
+
+  ##  @libraryclass    Provide services to get BIOS ID information.
+  BiosIdLib|Include/Library/BiosIdLib.h
+
+[Guids]
+  ## Include Include/Guid/BiosId.h
+  gBiosIdGuid = { 0xC3E36D09, 0x8294, 0x4b97, { 0xA8, 0x57, 0xD5, 0x28, 0x8F, 0xE3, 0x3E, 0x28 } }
+
+  ## GUID to publish BIOS information HOB
+  gBiosInfoGuid = { 0x09d0d15c, 0xe9f0, 0x4dfc, {0x9e, 0x0b, 0x39, 0x33, 0x1f, 0xca, 0x66, 0x85} }
+
+  ## {7F4EE1A3-C1F3-43E4-BA1A-39DCDE46C343}
+  gBoardModulePkgTokenSpaceGuid = { 0x7f4ee1a3, 0xc1f3, 0x43e4, { 0xba, 0x1a, 0x39, 0xdc, 0xde, 0x46, 0xc3, 0x43 } }
+
+[PcdsFixedAtBuild]
+

--- a/BoardModulePkg/BoardModulePkg.dsc
+++ b/BoardModulePkg/BoardModulePkg.dsc
@@ -1,0 +1,86 @@
+## @file
+# This package provides the modules that build for a full feature platform.
+# This BoardModulePkg should only depend on EDKII Core packages and MinPlatformPkg.
+#
+# The DEC files are used by the utilities that parse DSC and
+# INF files to generate AutoGen.c and AutoGen.h files
+# for the build infrastructure.
+#
+# Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  PLATFORM_NAME                  = BoardModulePkg
+  PLATFORM_GUID                  = D36FD4CC-6CD1-4CE6-AA0B-EDB469DAE48B
+  PLATFORM_VERSION               = 0.1
+  DSC_SPECIFICATION              = 0x00010005
+  OUTPUT_DIRECTORY               = Build/BoardModulePkg
+  SUPPORTED_ARCHITECTURES        = IA32|X64
+  BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
+  SKUID_IDENTIFIER               = DEFAULT
+
+!include MdePkg/MdeLibs.dsc.inc
+
+[LibraryClasses]
+  BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
+  BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+  PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
+  UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+  DxeServicesLib|MdePkg/Library/DxeServicesLib/DxeServicesLib.inf
+  PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+  PeimEntryPoint|MdePkg/Library/PeimEntryPoint/PeimEntryPoint.inf
+  UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
+  DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
+  UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+  UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
+
+[LibraryClasses.common.PEIM]
+  HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf
+  MemoryAllocationLib|MdePkg/Library/PeiMemoryAllocationLib/PeiMemoryAllocationLib.inf
+
+[LibraryClasses.IA32.PEIM, LibraryClasses.X64.PEIM]
+  PeiServicesTablePointerLib|MdePkg/Library/PeiServicesTablePointerLibIdt/PeiServicesTablePointerLibIdt.inf
+
+[LibraryClasses.common.DXE_DRIVER]
+  HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
+  MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+
+[LibraryClasses.common.UEFI_DRIVER]
+  HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
+  MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+
+[LibraryClasses.common.DXE_RUNTIME_DRIVER]
+  HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
+  MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+
+###################################################################################################
+#
+# Components Section - list of the modules and components that will be processed by compilation
+#                      tools and the EDK II tools to generate PE32/PE32+/Coff image files.
+#
+# Note: The EDK II DSC file is not used to specify how compiled binary images get placed
+#       into firmware volume images. This section is just a list of modules to compile from
+#       source into UEFI-compliant binaries.
+#       It is the FDF file that contains information on combining binary files into firmware
+#       volume images, whose concept is beyond UEFI and is described in PI specification.
+#       Binary modules do not need to be listed in this section, as they should be
+#       specified in the FDF file. For example: Shell binary (Shell_Full.efi), FAT binary (Fat.efi),
+#       Logo (Logo.bmp), and etc.
+#       There may also be modules listed in this section that are not required in the FDF file,
+#       When a module listed here is excluded from FDF file, then UEFI-compliant binary will be
+#       generated for it, but the binary will not be put into any firmware volume.
+#
+###################################################################################################
+
+[Components]
+  BoardModulePkg/Library/CmosAccessLib/CmosAccessLib.inf
+  BoardModulePkg/Library/PlatformCmosAccessLibNull/PlatformCmosAccessLibNull.inf
+
+  BoardModulePkg/Library/BiosIdLib/DxeBiosIdLib.inf
+  BoardModulePkg/Library/BiosIdLib/PeiBiosIdLib.inf
+

--- a/BoardModulePkg/Include/Guid/BiosId.h
+++ b/BoardModulePkg/Include/Guid/BiosId.h
@@ -1,0 +1,54 @@
+/** @file
+  GUID and definitions for BIOS ID.
+
+Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _BIOS_ID_GUID_H_
+#define _BIOS_ID_GUID_H_
+
+#include <Pi/PiHob.h>
+
+extern EFI_GUID gBiosIdGuid;
+
+//
+// $(BOARD_ID)$(BOARD_REV).$(BOARD_EXT).$(VERSION_MAJOR).$(BUILD_TYPE)$(VERSION_MINOR).YYMMDDHHMM
+//
+// Example: "TRFTCRB1.000.0008.D03.1501301017"
+//
+#pragma pack(1)
+
+typedef struct {
+  CHAR16    BoardId[7];             // "TRFTCRB"
+  CHAR16    BoardRev;               // "1"
+  CHAR16    Dot1;                   // "."
+  CHAR16    BoardExt[3];            // "000"
+  CHAR16    Dot2;                   // "."
+  CHAR16    VersionMajor[4];        // "0008"
+  CHAR16    Dot3;                   // "."
+  CHAR16    BuildType;              // "D"
+  CHAR16    VersionMinor[2];        // "03"
+  CHAR16    Dot4;                   // "."
+  CHAR16    TimeStamp[10];          // "YYMMDDHHMM"
+  CHAR16    NullTerminator;         // 0x0000
+} BIOS_ID_STRING;
+
+//
+// A signature precedes the BIOS ID string in the FV to enable search by external tools.
+//
+typedef struct {
+  UINT8             Signature[8];   // "$IBIOSI$"
+  BIOS_ID_STRING    BiosIdString;   // "TRFTCRB1.000.0008.D03.1501301017"
+} BIOS_ID_IMAGE;
+
+#pragma pack()
+
+typedef struct {
+  EFI_HOB_GUID_TYPE GuidType;
+  BIOS_ID_IMAGE     BiosIdImage;
+} BIOS_ID_HOB;
+
+#endif
+

--- a/BoardModulePkg/Include/Guid/BiosInfo.h
+++ b/BoardModulePkg/Include/Guid/BiosInfo.h
@@ -1,0 +1,61 @@
+/** @file
+  Definitions and GUID for BIOS INFO.
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _BIOS_INFO_H_
+#define _BIOS_INFO_H_
+
+//
+// BIOS INFO data structure
+// This is self contained data structure for BIOS info for TXT
+//
+#pragma pack (1)
+#define BIOS_INFO_SIGNATURE  SIGNATURE_64 ('$', 'B', 'I', 'O', 'S', 'I', 'F', '$')
+typedef struct {
+  UINT64            Signature;
+  UINT32            EntryCount;
+  UINT32            Reserved;
+//BIOS_INFO_STRUCT  Struct[EntryCount];
+} BIOS_INFO_HEADER;
+
+//
+// BIOS_INFO_STRUCT attributes
+// bits[0:3] means general attributes
+// bits[4:7] means type specific attributes
+//
+#define BIOS_INFO_STRUCT_ATTRIBUTE_GENERAL_EXCLUDE_FROM_FIT  0x01
+#define BIOS_INFO_STRUCT_ATTRIBUTE_MICROCODE_WHOLE_REGION    0x10
+#define BIOS_INFO_STRUCT_ATTRIBUTE_BIOS_POST_IBB             0x10
+#define BIOS_INFO_STRUCT_ATTRIBUTE_BIOS_NON_IBB              0x20
+
+typedef struct {
+  //
+  // FitTable entry type
+  //
+  UINT8    Type;
+  //
+  // BIOS_INFO_STRUCT attributes
+  //
+  UINT8    Attributes;
+  //
+  // FitTable entry version
+  //
+  UINT16   Version;
+  //
+  // FitTable entry real size
+  //
+  UINT32   Size;
+  //
+  // FitTable entry address
+  //
+  UINT64   Address;
+} BIOS_INFO_STRUCT;
+
+extern EFI_GUID  gBiosInfoGuid;
+
+#pragma pack ()
+
+#endif

--- a/BoardModulePkg/Include/Library/BiosIdLib.h
+++ b/BoardModulePkg/Include/Library/BiosIdLib.h
@@ -1,0 +1,57 @@
+/** @file
+  BIOS ID library functions.
+
+  This library provides functions to get BIOS ID, VERSION, DATE and TIME.
+
+  These functions in this file can be called during DXE and cannot be called during runtime
+  or in SMM which should use a RT or SMM library.
+
+Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _BIOS_ID_LIB_H_
+#define _BIOS_ID_LIB_H_
+
+#include <Guid/BiosId.h>
+
+/**
+  This function returns BIOS ID by searching HOB or FV.
+  It also debug print the BIOS ID found.
+
+  @param[out] BiosIdImage   The BIOS ID got from HOB or FV. It is optional,
+                            no BIOS ID will be returned if it is NULL as input.
+
+  @retval EFI_SUCCESS               BIOS ID has been got successfully.
+  @retval EFI_NOT_FOUND             BIOS ID image is not found, and no parameter will be modified.
+
+**/
+EFI_STATUS
+EFIAPI
+GetBiosId (
+  OUT BIOS_ID_IMAGE     *BiosIdImage OPTIONAL
+  );
+
+/**
+  This function returns the BIOS Version & Release Date and Time by getting and converting BIOS ID.
+
+  @param[out] BiosVersion       The Bios Version out of the conversion.
+  @param[out] BiosReleaseDate   The Bios Release Date out of the conversion.
+  @param[out] BiosReleaseTime   The Bios Release Time out of the conversion.
+
+  @retval EFI_SUCCESS               BIOS Version & Release Date and Time have been got successfully.
+  @retval EFI_NOT_FOUND             BIOS ID image is not found, and no parameter will be modified.
+  @retval EFI_INVALID_PARAMETER     All the parameters are NULL.
+
+**/
+EFI_STATUS
+EFIAPI
+GetBiosVersionDateTime (
+  OUT CHAR16    *BiosVersion, OPTIONAL
+  OUT CHAR16    *BiosReleaseDate, OPTIONAL
+  OUT CHAR16    *BiosReleaseTime OPTIONAL
+  );
+
+#endif
+

--- a/BoardModulePkg/Include/Library/CmosAccessLib.h
+++ b/BoardModulePkg/Include/Library/CmosAccessLib.h
@@ -1,0 +1,106 @@
+/** @file
+  CmosAccessLib header file.
+
+Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _CMOS_ACCESS_LIB_H_
+#define _CMOS_ACCESS_LIB_H_
+
+/**
+  Read a byte value from a CMOS address.
+
+  @param [in] Address   Location to read from CMOS
+
+  @return The byte value read from the CMOS address.
+**/
+UINT8
+EFIAPI
+CmosRead8 (
+  IN  UINT8 Address
+  );
+
+/**
+  Write a byte value to a CMOS address.
+
+  @param [in] Address Location to write to CMOS.
+  @param [in] Data    The byte value write to the CMOS address.
+**/
+VOID
+EFIAPI
+CmosWrite8 (
+  IN UINT8 Address,
+  IN UINT8 Data
+  );
+
+/**
+  Read a word value from a CMOS address.
+
+  @param [in] Address   Location to read from CMOS
+
+  @return The word value read from the CMOS address.
+**/
+UINT16
+EFIAPI
+CmosRead16 (
+  IN  UINT8  Address
+  );
+
+/**
+  Write a word value to a CMOS address.
+
+  @param [in] Address Location to write to CMOS.
+  @param [in] Data    The word value write to the CMOS address.
+**/
+VOID
+EFIAPI
+CmosWrite16 (
+  IN UINT8  Address,
+  IN UINT16 Data
+  );
+
+/**
+  Read a dword value from a CMOS address.
+
+  @param [in] Address   Location to read from CMOS
+
+  @return The dword value read from the CMOS address.
+**/
+UINT32
+EFIAPI
+CmosRead32 (
+  IN  UINT8  Address
+  );
+
+/**
+  Write a dword value to a CMOS address.
+
+  @param [in] Address Location to write to CMOS.
+  @param [in] Data    The dword value write to the CMOS address.
+**/
+VOID
+EFIAPI
+CmosWrite32 (
+  IN UINT8  Address,
+  IN UINT32 Data
+  );
+
+/**
+  Initialize the CMOS.
+
+  It initialize the CMOS area when Force is TRUE or the checksum is incorrect.
+
+  @param[in]  Force  TRUE indicating initializing the CMOS area without checking the checksum.
+
+  @retval TRUE  The CMOS is initialized to default value.
+  @retval FALSE The CMOS isn't initialized to default value.
+**/
+BOOLEAN
+EFIAPI
+CmosInit (
+  IN  BOOLEAN     Force
+  );
+
+#endif // _CMOS_ACCESS_LIB_H_

--- a/BoardModulePkg/Include/Library/PlatformCmosAccessLib.h
+++ b/BoardModulePkg/Include/Library/PlatformCmosAccessLib.h
@@ -1,0 +1,68 @@
+/** @file
+  Platform CMOS Access Library Header File.
+
+Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _PLATFORM_CMOS_ACCESS_LIB_H_
+#define _PLATFORM_CMOS_ACCESS_LIB_H_
+
+///
+/// Flag indicating checksum calculation doesn't include this location.
+/// NOTE: If a location isn't shown in platform CMOS entry table,
+///       it means checksum calculation doesn't include the location.
+///
+#define CMOS_EXCLUDE_FROM_CHECKSUM    BIT0
+
+///
+/// Flag indicating initialization doesn't cover this location.
+/// NOTE: If a location isn't shown in platform CMOS entry table,
+///       it means the location is initialized with CMOS_DEFAULT_VALUE (0).
+///
+#define CMOS_EXCLUDE_FROM_INIT_DATA   BIT1
+
+///
+/// Flag indicating the location cannot be accessed.
+/// NOTE: 0x0 ~ 0xD is implictly inaccessible.
+///
+#define CMOS_EXCLUDE_FROM_ACCESS      (BIT3 | CMOS_EXCLUDE_FROM_CHECKSUM | CMOS_EXCLUDE_FROM_INIT_DATA)
+
+///
+/// Flag indicating the checksum location
+/// NOTE: At most two entries can have this flag set.
+///
+#define CMOS_CHECKSUM_LOCATION        (BIT2 | CMOS_EXCLUDE_FROM_CHECKSUM | CMOS_EXCLUDE_FROM_INIT_DATA)
+
+#define CMOS_DEFAULT_VALUE            0x00
+
+typedef struct {
+  UINT8 Address;
+  UINT8 DefaultValue;
+  UINT8 Attributes;
+} CMOS_ENTRY;
+
+/**
+  Return the platform CMOS entries.
+
+  @param [out] EntryCount Return the count of platform CMOS entries.
+
+  @return Platform CMOS entries.
+**/
+CMOS_ENTRY *
+EFIAPI
+PlatformCmosGetEntry (
+  OUT UINTN       *EntryCount
+  );
+
+/**
+  Return the NMI enable status.
+**/
+BOOLEAN
+EFIAPI
+PlatformCmosGetNmiState (
+  VOID
+  );
+
+#endif // _PLATFORM_CMOS_ACCESS_LIB_H_

--- a/BoardModulePkg/Library/BiosIdLib/DxeBiosIdLib.c
+++ b/BoardModulePkg/Library/BiosIdLib/DxeBiosIdLib.c
@@ -1,0 +1,175 @@
+/** @file
+  Boot service DXE BIOS ID library implementation.
+
+  These functions in this file can be called during DXE and cannot be called during runtime
+  or in SMM which should use a RT or SMM library.
+
+
+Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiDxe.h>
+#include <Library/BaseLib.h>
+#include <Library/HobLib.h>
+#include <Library/DxeServicesLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/HobLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BiosIdLib.h>
+
+#include <Guid/BiosId.h>
+
+/**
+  This function returns BIOS ID by searching HOB or FV.
+  It also debug print the BIOS ID found.
+
+  @param[out] BiosIdImage   The BIOS ID got from HOB or FV. It is optional,
+                            no BIOS ID will be returned if it is NULL as input.
+
+  @retval EFI_SUCCESS               BIOS ID has been got successfully.
+  @retval EFI_NOT_FOUND             BIOS ID image is not found, and no parameter will be modified.
+
+**/
+EFI_STATUS
+EFIAPI
+GetBiosId (
+  OUT BIOS_ID_IMAGE     *BiosIdImage OPTIONAL
+  )
+{
+  EFI_STATUS    Status;
+  BIOS_ID_IMAGE TempBiosIdImage;
+  VOID          *Address;
+  UINTN         Size;
+
+  Address = NULL;
+  Size = 0;
+
+  if (BiosIdImage == NULL) {
+    //
+    // It is NULL as input, so no BIOS ID will be returned.
+    // Use temp buffer to hold the BIOS ID.
+    //
+    BiosIdImage = &TempBiosIdImage;
+  }
+
+  Address = GetFirstGuidHob (&gBiosIdGuid);
+  if (Address != NULL) {
+    Size = sizeof (BIOS_ID_IMAGE);
+    CopyMem ((VOID *) BiosIdImage, GET_GUID_HOB_DATA (Address), Size);
+
+    DEBUG ((EFI_D_INFO, "DXE get BIOS ID from HOB successfully\n"));
+    DEBUG ((EFI_D_INFO, "BIOS ID: %s\n", (CHAR16 *) (&(BiosIdImage->BiosIdString))));
+    return EFI_SUCCESS;
+  }
+
+  Status = GetSectionFromAnyFv (
+             &gBiosIdGuid,
+             EFI_SECTION_RAW,
+             0,
+             &Address,
+             &Size
+             );
+  if ((Status == EFI_SUCCESS) && (Address != NULL)) {
+    //
+    // BIOS ID image is present in FV.
+    //
+    Size = sizeof (BIOS_ID_IMAGE);
+    CopyMem ((VOID *) BiosIdImage, Address, Size);
+    //
+    // GetSectionFromAnyFv () allocated buffer for Address, now free it.
+    //
+    FreePool (Address);
+
+    DEBUG ((EFI_D_INFO, "DXE get BIOS ID from FV successfully\n"));
+    DEBUG ((EFI_D_INFO, "BIOS ID: %s\n", (CHAR16 *) (&(BiosIdImage->BiosIdString))));
+    return EFI_SUCCESS;
+  }
+
+  DEBUG ((EFI_D_ERROR, "DXE get BIOS ID failed: %r\n", EFI_NOT_FOUND));
+  return EFI_NOT_FOUND;
+}
+
+/**
+  This function returns the BIOS Version & Release Date and Time by getting and converting BIOS ID.
+
+  @param[out] BiosVersion       The Bios Version out of the conversion.
+  @param[out] BiosReleaseDate   The Bios Release Date out of the conversion.
+  @param[out] BiosReleaseTime   The Bios Release Time out of the conversion.
+
+  @retval EFI_SUCCESS               BIOS Version & Release Date and Time have been got successfully.
+  @retval EFI_NOT_FOUND             BIOS ID image is not found, and no parameter will be modified.
+  @retval EFI_INVALID_PARAMETER     All the parameters are NULL.
+
+**/
+EFI_STATUS
+EFIAPI
+GetBiosVersionDateTime (
+  OUT CHAR16    *BiosVersion, OPTIONAL
+  OUT CHAR16    *BiosReleaseDate, OPTIONAL
+  OUT CHAR16    *BiosReleaseTime OPTIONAL
+  )
+{
+  EFI_STATUS        Status;
+  BIOS_ID_IMAGE     BiosIdImage;
+
+  if ((BiosVersion == NULL) && (BiosReleaseDate == NULL) && (BiosReleaseTime == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetBiosId (&BiosIdImage);
+  if (EFI_ERROR (Status)) {
+    return EFI_NOT_FOUND;
+  }
+
+  if (BiosVersion != NULL) {
+    //
+    // Fill the BiosVersion data from the BIOS ID.
+    //
+    CopyMem (BiosVersion, &(BiosIdImage.BiosIdString), sizeof (BIOS_ID_STRING));
+  }
+
+  if (BiosReleaseDate != NULL) {
+    //
+    // Fill the build timestamp date from the BIOS ID in the "MM/DD/YY" format.
+    //
+    BiosReleaseDate[0] = BiosIdImage.BiosIdString.TimeStamp[2];
+    BiosReleaseDate[1] = BiosIdImage.BiosIdString.TimeStamp[3];
+    BiosReleaseDate[2] = (CHAR16) ((UINT8) ('/'));
+
+    BiosReleaseDate[3] = BiosIdImage.BiosIdString.TimeStamp[4];
+    BiosReleaseDate[4] = BiosIdImage.BiosIdString.TimeStamp[5];
+    BiosReleaseDate[5] = (CHAR16) ((UINT8) ('/'));
+
+    //
+    // Add 20 for SMBIOS table
+    // Current Linux kernel will misjudge 09 as year 0, so using 2009 for SMBIOS table
+    //
+    BiosReleaseDate[6] = '2';
+    BiosReleaseDate[7] = '0';
+    BiosReleaseDate[8] = BiosIdImage.BiosIdString.TimeStamp[0];
+    BiosReleaseDate[9] = BiosIdImage.BiosIdString.TimeStamp[1];
+
+    BiosReleaseDate[10] = (CHAR16) ((UINT8) ('\0'));
+  }
+
+  if (BiosReleaseTime != NULL) {
+
+    //
+    // Fill the build timestamp time from the BIOS ID in the "HH:MM" format.
+    //
+    BiosReleaseTime[0] = BiosIdImage.BiosIdString.TimeStamp[6];
+    BiosReleaseTime[1] = BiosIdImage.BiosIdString.TimeStamp[7];
+    BiosReleaseTime[2] = (CHAR16) ((UINT8) (':'));
+
+    BiosReleaseTime[3] = BiosIdImage.BiosIdString.TimeStamp[8];
+    BiosReleaseTime[4] = BiosIdImage.BiosIdString.TimeStamp[9];
+
+    BiosReleaseTime[5] = (CHAR16) ((UINT8) ('\0'));
+  }
+
+  return  EFI_SUCCESS;
+}
+

--- a/BoardModulePkg/Library/BiosIdLib/DxeBiosIdLib.inf
+++ b/BoardModulePkg/Library/BiosIdLib/DxeBiosIdLib.inf
@@ -1,0 +1,42 @@
+### @file
+#  DXE BIOS ID library.
+#
+# Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+[Defines]
+  INF_VERSION                   = 0x00010005
+  BASE_NAME                     = DxeBiosIdLib
+  FILE_GUID                     = D72C04E9-C6C4-49d5-BC16-BD612EBA127B
+  MODULE_TYPE                   = DXE_DRIVER
+  VERSION_STRING                = 1.0
+  LIBRARY_CLASS                 = BiosIdLib|DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER SMM_CORE
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES          = IA32 X64
+#
+
+[Sources.common]
+  DxeBiosIdLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BoardModulePkg/BoardModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DxeServicesLib
+  BaseMemoryLib
+  HobLib
+  MemoryAllocationLib
+  DebugLib
+
+[Guids]
+  ## SOMETIMES_CONSUMES ## HOB
+  ## SOMETIMES_CONSUMES ## GUID
+  gBiosIdGuid
+

--- a/BoardModulePkg/Library/BiosIdLib/PeiBiosIdLib.c
+++ b/BoardModulePkg/Library/BiosIdLib/PeiBiosIdLib.c
@@ -1,0 +1,191 @@
+/** @file
+  Boot service PEI BIOS ID library implementation.
+
+Copyright (c) 2-015 - 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/BaseLib.h>
+#include <Library/PeiServicesLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/HobLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BiosIdLib.h>
+
+#include <Guid/BiosId.h>
+
+/**
+  This function returns BIOS ID by searching HOB or FV.
+  It also debug print the BIOS ID found.
+
+  @param[out] BiosIdImage   The BIOS ID got from HOB or FV. It is optional,
+                            no BIOS ID will be returned if it is NULL as input.
+
+  @retval EFI_SUCCESS               BIOS ID has been got successfully.
+  @retval EFI_NOT_FOUND             BIOS ID image is not found, and no parameter will be modified.
+
+**/
+EFI_STATUS
+EFIAPI
+GetBiosId (
+  OUT BIOS_ID_IMAGE     *BiosIdImage OPTIONAL
+  )
+{
+  EFI_STATUS            Status;
+  BIOS_ID_IMAGE         TempBiosIdImage;
+  VOID                  *Address;
+  UINTN                 Size;
+  UINTN                 Instance;
+  EFI_PEI_FV_HANDLE     VolumeHandle;
+  EFI_PEI_FILE_HANDLE   FileHandle;
+
+  Address = NULL;
+  Size = 0;
+
+  if (BiosIdImage == NULL) {
+    //
+    // It is NULL as input, so no BIOS ID will be returned.
+    // Use temp buffer to hold the BIOS ID.
+    //
+    BiosIdImage = &TempBiosIdImage;
+  }
+
+  Address = GetFirstGuidHob (&gBiosIdGuid);
+  if (Address != NULL) {
+    Size = sizeof (BIOS_ID_IMAGE);
+    CopyMem ((VOID *) BiosIdImage, GET_GUID_HOB_DATA (Address), Size);
+
+    DEBUG ((EFI_D_INFO, "PEI get BIOS ID from HOB successfully\n"));
+    DEBUG ((EFI_D_INFO, "BIOS ID: %s\n", (CHAR16 *) (&(BiosIdImage->BiosIdString))));
+    return EFI_SUCCESS;
+  }
+
+  VolumeHandle = NULL;
+  Instance = 0;
+  while (TRUE) {
+    //
+    // Traverse all firmware volume instances.
+    //
+    Status = PeiServicesFfsFindNextVolume (Instance, &VolumeHandle);
+    if (EFI_ERROR (Status)) {
+      break;
+    }
+
+    FileHandle = NULL;
+    Status = PeiServicesFfsFindFileByName (&gBiosIdGuid, VolumeHandle, &FileHandle);
+    if (!EFI_ERROR (Status)) {
+      //
+      // Search RAW section.
+      //
+      Status = PeiServicesFfsFindSectionData (EFI_SECTION_RAW, FileHandle, &Address);
+      if (!EFI_ERROR (Status)) {
+        //
+        // BIOS ID image is present in this FV.
+        //
+        Size = sizeof (BIOS_ID_IMAGE);
+        CopyMem ((VOID *) BiosIdImage, Address, Size);
+
+        DEBUG ((EFI_D_INFO, "PEI get BIOS ID from FV successfully\n"));
+        DEBUG ((EFI_D_INFO, "BIOS ID: %s\n", (CHAR16 *) (&(BiosIdImage->BiosIdString))));
+
+        //
+        // Build GUID HOB for the BIOS ID image.
+        //
+        BuildGuidDataHob (&gBiosIdGuid, Address, Size);
+        return EFI_SUCCESS;
+      }
+    }
+
+    //
+    // Search the next volume.
+    //
+    Instance++;
+  }
+
+  DEBUG ((EFI_D_ERROR, "PEI get BIOS ID failed: %r\n", EFI_NOT_FOUND));
+  return EFI_NOT_FOUND;
+}
+
+/**
+  This function returns the BIOS Version & Release Date and Time by getting and converting BIOS ID.
+
+  @param[out] BiosVersion       The Bios Version out of the conversion.
+  @param[out] BiosReleaseDate   The Bios Release Date out of the conversion.
+  @param[out] BiosReleaseTime   The Bios Release Time out of the conversion.
+
+  @retval EFI_SUCCESS               BIOS Version & Release Date and Time have been got successfully.
+  @retval EFI_NOT_FOUND             BIOS ID image is not found, and no parameter will be modified.
+  @retval EFI_INVALID_PARAMETER     All the parameters are NULL.
+
+**/
+EFI_STATUS
+EFIAPI
+GetBiosVersionDateTime (
+  OUT CHAR16    *BiosVersion, OPTIONAL
+  OUT CHAR16    *BiosReleaseDate, OPTIONAL
+  OUT CHAR16    *BiosReleaseTime OPTIONAL
+  )
+{
+  EFI_STATUS        Status;
+  BIOS_ID_IMAGE     BiosIdImage;
+
+  if ((BiosVersion == NULL) && (BiosReleaseDate == NULL) && (BiosReleaseTime == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetBiosId (&BiosIdImage);
+  if (EFI_ERROR (Status)) {
+    return EFI_NOT_FOUND;
+  }
+
+  if (BiosVersion != NULL) {
+    //
+    // Fill the BiosVersion data from the BIOS ID.
+    //
+    CopyMem (BiosVersion, &(BiosIdImage.BiosIdString), sizeof (BIOS_ID_STRING));
+  }
+
+  if (BiosReleaseDate != NULL) {
+    //
+    // Fill the build timestamp date from the BIOS ID in the "MM/DD/YY" format.
+    //
+    BiosReleaseDate[0] = BiosIdImage.BiosIdString.TimeStamp[2];
+    BiosReleaseDate[1] = BiosIdImage.BiosIdString.TimeStamp[3];
+    BiosReleaseDate[2] = (CHAR16) ((UINT8) ('/'));
+
+    BiosReleaseDate[3] = BiosIdImage.BiosIdString.TimeStamp[4];
+    BiosReleaseDate[4] = BiosIdImage.BiosIdString.TimeStamp[5];
+    BiosReleaseDate[5] = (CHAR16) ((UINT8) ('/'));
+
+    //
+    // Add 20 for SMBIOS table
+    // Current Linux kernel will misjudge 09 as year 0, so using 2009 for SMBIOS table
+    //
+    BiosReleaseDate[6] = '2';
+    BiosReleaseDate[7] = '0';
+    BiosReleaseDate[8] = BiosIdImage.BiosIdString.TimeStamp[0];
+    BiosReleaseDate[9] = BiosIdImage.BiosIdString.TimeStamp[1];
+
+    BiosReleaseDate[10] = (CHAR16) ((UINT8) ('\0'));
+  }
+
+  if (BiosReleaseTime != NULL) {
+
+    //
+    // Fill the build timestamp time from the BIOS ID in the "HH:MM" format.
+    //
+    BiosReleaseTime[0] = BiosIdImage.BiosIdString.TimeStamp[6];
+    BiosReleaseTime[1] = BiosIdImage.BiosIdString.TimeStamp[7];
+    BiosReleaseTime[2] = (CHAR16) ((UINT8) (':'));
+
+    BiosReleaseTime[3] = BiosIdImage.BiosIdString.TimeStamp[8];
+    BiosReleaseTime[4] = BiosIdImage.BiosIdString.TimeStamp[9];
+
+    BiosReleaseTime[5] = (CHAR16) ((UINT8) ('\0'));
+  }
+
+  return  EFI_SUCCESS;
+}
+

--- a/BoardModulePkg/Library/BiosIdLib/PeiBiosIdLib.inf
+++ b/BoardModulePkg/Library/BiosIdLib/PeiBiosIdLib.inf
@@ -1,0 +1,42 @@
+### @file
+# PEI BIOS ID library.
+#
+# Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+[Defines]
+  INF_VERSION                   = 0x00010005
+  BASE_NAME                     = PeiBiosIdLib
+  FILE_GUID                     = C97DA4CA-67C1-4523-9A78-CE8CAFE6E239
+  MODULE_TYPE                   = PEIM
+  VERSION_STRING                = 1.0
+  LIBRARY_CLASS                 = BiosIdLib|PEI_CORE PEIM
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES          = IA32 X64
+#
+
+[Sources.common]
+  PeiBiosIdLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BoardModulePkg/BoardModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  PeiServicesLib
+  BaseMemoryLib
+  HobLib
+  DebugLib
+
+[Guids]
+  ## SOMETIMES_CONSUMES ## HOB
+  ## SOMETIMES_PRODUCES ## HOB
+  ## SOMETIMES_CONSUMES ## GUID
+  gBiosIdGuid
+

--- a/BoardModulePkg/Library/CmosAccessLib/CmosAccessLib.c
+++ b/BoardModulePkg/Library/CmosAccessLib/CmosAccessLib.c
@@ -1,0 +1,486 @@
+/** @file
+  CmosAccessLib implementation.
+
+Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "CmosAccessLibInternal.h"
+
+/**
+  Return the entry for the specified address in entries returned
+  from platform.
+
+  @param [in] Address  The CMOS address to find.
+
+  @return A pointer to CMOS_ENTRY for the specified address,
+          or NULL if not found.
+**/
+CMOS_ENTRY *
+CmosAccessLibLocateEntry (
+  IN UINT8      Address
+  )
+{
+  UINTN              Index;
+  UINTN              Count;
+  CMOS_ENTRY         *Entries;
+
+  Entries = PlatformCmosGetEntry (&Count);
+  for (Index = 0; Index < Count; Index++) {
+    if (Entries[Index].Address == Address) {
+      return &Entries[Index];
+    }
+  }
+
+  return NULL;
+}
+
+/**
+  Test the attributes of the Entry and return ValueIfSet if test passes
+  or !ValueIfSet if test fails. It returns DefaultValue if the Entry is
+  NULL.
+
+  @param [in] Address      The CMOS address.
+  @param [in] Attributes   The attributes to test.
+  @param [in] ValueIfSet   The value to return if test passes.
+  @param [in] DefaultValue The value to return if Entry is NULL.
+  @param [in] Entry        Pointer to entry.
+
+  @retval ValueIfSet   If test passes.
+  @retval !ValueIfSet  If test fails.
+  @retval DefaultValue If the Entry is NULL.
+**/
+BOOLEAN
+CmosAccessLibCheckAttribute (
+  IN UINT8      Address,
+  IN UINT8      Attributes,
+  IN BOOLEAN    ValueIfSet,
+  IN BOOLEAN    DefaultValue,
+  IN CMOS_ENTRY *Entry        OPTIONAL
+  )
+{
+  if (Entry != NULL) {
+    ASSERT (Entry->Address == Address);
+    if ((Entry->Attributes & Attributes) == Attributes) {
+      return ValueIfSet;
+    } else {
+      return !ValueIfSet;
+    }
+  }
+
+  return DefaultValue;
+}
+
+/**
+  Check if the CMOS address needs Checksum calculation.
+
+  @param [in] Address CMOS address to be checked
+  @param [in] Entry   Pointer to entry.
+
+  @retval TRUE       CMOS address needs Checksum calculation.
+  @retval FALSE      CMOS address doesn't need Checksum calculation.
+**/
+BOOLEAN
+CmosAccessLibNeedChecksum (
+  IN UINT8       Address,
+  IN CMOS_ENTRY  *Entry OPTIONAL
+  )
+{
+  return CmosAccessLibCheckAttribute (Address, CMOS_EXCLUDE_FROM_CHECKSUM, FALSE, FALSE, Entry);
+}
+
+
+/**
+  Check if the CMOS address needs to fill default data.
+
+  @param [in] Address CMOS address to be checked
+  @param [in] Entry   Pointer to entry.
+
+  @retval TRUE       CMOS address need to fill default data.
+  @retval FALSE      CMOS address doesn't need to fill default data.
+**/
+BOOLEAN
+CmosAccessLibNeedFillDefault (
+  IN UINT8       Address,
+  IN CMOS_ENTRY  *Entry OPTIONAL
+  )
+{
+  return CmosAccessLibCheckAttribute (Address, CMOS_EXCLUDE_FROM_INIT_DATA, FALSE, TRUE, Entry);
+}
+
+/**
+  Check if the CMOS address is accessible.
+
+  @param [in] Address CMOS address to be checked.
+  @param [in] Entry   Pointer to entry.
+
+  @retval TRUE       CMOS address is accessible.
+  @retval FALSE      CMOS address isn't accessible.
+**/
+BOOLEAN
+CmosAccessLibIsAccessible (
+  IN UINT8       Address,
+  IN CMOS_ENTRY  *Entry OPTIONAL
+  )
+{
+  //
+  // CMOS 0-9, A, B, C, D are for RTC.
+  //
+  if (Address <= 0xD) {
+    return FALSE;
+  }
+  return CmosAccessLibCheckAttribute (Address, CMOS_EXCLUDE_FROM_ACCESS, FALSE, TRUE, Entry);
+}
+
+/**
+  Return the CMOS location to store checksum.
+
+  @param [out] Location Return the CMOS location to store the checksum.
+**/
+VOID
+CmosAccessLibGetChecksumLocation (
+  OUT CMOS_CHECKSUM_LOCATION_INFO *Location
+  )
+{
+  UINTN                       Index;
+  UINTN                       Count;
+  CMOS_ENTRY                  *Entries;
+
+  Location->Length = 0;
+
+  Entries = PlatformCmosGetEntry (&Count);
+  for (Index = 0; Index < Count; Index++) {
+    if ((Entries[Index].Attributes & CMOS_CHECKSUM_LOCATION) == CMOS_CHECKSUM_LOCATION) {
+      Location->Length++;
+      if (Location->Length == 1) {
+        Location->LowByteAddress = Entries[Index].Address;
+      } else if (Location->Length == 2) {
+        Location->HighByteAddress = Entries[Index].Address;
+        break;
+      }
+    }
+  }
+
+  ASSERT (Location->Length <= 2);
+}
+
+/**
+  Calculate the sum of CMOS values who need checksum calculation.
+
+  @param [in] Location The CMOS location to store the checksum.
+
+  @return The sum.
+**/
+UINT16
+CmosAccessLibCalculateSum (
+  IN CMOS_CHECKSUM_LOCATION_INFO *Location
+  )
+{
+  UINT16                      Sum;
+  UINTN                       Index;
+  UINTN                       Count;
+  CMOS_ENTRY                  *Entries;
+
+  if (Location->Length == 0) {
+    return 0;
+  }
+
+  Sum = 0;
+  Entries = PlatformCmosGetEntry (&Count);
+  for (Index = 0; Index < Count; Index++) {
+    if (CmosAccessLibNeedChecksum (Entries[Index].Address, &Entries[Index])) {
+      Sum += CmosRead8 (Entries[Index].Address);
+    }
+  }
+
+  if (Location->Length == 1) {
+    return (UINT8) Sum;
+  } else {
+    return Sum;
+  }
+}
+
+/**
+  Return the checksum value stored in CMOS.
+
+  @param [in] Location The CMOS location to store the checksum.
+
+  @return The checksum value.
+**/
+UINT16
+CmosAccessLibReadChecksum (
+  IN CMOS_CHECKSUM_LOCATION_INFO *Location
+  )
+{
+  UINT16                      Checksum;
+
+  Checksum = 0;
+
+  switch (Location->Length) {
+  case 2:
+    Checksum = (CmosRead8 (Location->HighByteAddress) << 8);
+    //
+    // Fall to case 1 to get the low byte value
+    //
+  case 1:
+    Checksum += CmosRead8 (Location->LowByteAddress);
+    break;
+
+  default:
+    break;
+  }
+  return Checksum;
+}
+
+
+/**
+  Write the Checksum to appropriate address.
+
+  @param [in] Location The CMOS location to store the checksum.
+  @param [in] Checksum The checksum value.
+**/
+VOID
+CmosAccessLibWriteChecksum (
+  CMOS_CHECKSUM_LOCATION_INFO *Location,
+  IN UINT16                   Checksum
+  )
+{
+
+  switch (Location->Length) {
+  case 0:
+    break;
+  case 2:
+    CmosWrite8 (Location->HighByteAddress, Checksum >> 8);
+    //
+    // Fall to case 1 to update low byte value
+    //
+  case 1:
+    CmosWrite8 (Location->LowByteAddress, (UINT8) Checksum);
+    break;
+  }
+}
+
+/**
+  Read a byte value from a CMOS address.
+
+  @param [in] Address   Location to read from CMOS
+
+  @return The byte value read from the CMOS address.
+**/
+UINT8
+EFIAPI
+CmosRead8 (
+  IN  UINT8 Address
+  )
+{
+  if (!CmosAccessLibIsAccessible (Address, CmosAccessLibLocateEntry (Address))) {
+    return 0xFF;
+  }
+
+  if (Address <= CMOS_BANK0_LIMIT) {
+    if (PlatformCmosGetNmiState ()) {
+      Address |= BIT7;
+    }
+    IoWrite8 (PORT_70, Address);
+    return IoRead8 (PORT_71);
+  } else {
+    IoWrite8 (PORT_72, Address);
+    return IoRead8 (PORT_73);
+  }
+}
+
+/**
+  Write a byte value to a CMOS address.
+
+  It's an internal function that doesn't update the checksum.
+
+  @param [in] Address Location to write to CMOS.
+  @param [in] Data    The byte value write to the CMOS address.
+**/
+VOID
+CmosAccessLibICmosWrite8 (
+  IN UINT8 Address,
+  IN UINT8 Data
+  )
+{
+  if (Address <= CMOS_BANK0_LIMIT) {
+    if (PlatformCmosGetNmiState ()) {
+      Address |= BIT7;
+    }
+    IoWrite8 (PORT_70, Address);
+    IoWrite8 (PORT_71, Data);
+  } else {
+    IoWrite8 (PORT_72, Address);
+    IoWrite8 (PORT_73, Data);
+  }
+}
+
+/**
+  Write a byte value to a CMOS address.
+
+  @param [in] Address Location to write to CMOS.
+  @param [in] Data    The byte value write to the CMOS address.
+**/
+VOID
+EFIAPI
+CmosWrite8 (
+  IN UINT8 Address,
+  IN UINT8 Data
+  )
+{
+  UINT8                       OriginalData;
+  CMOS_ENTRY                  *Entry;
+  CMOS_CHECKSUM_LOCATION_INFO ChecksumLocation;
+
+  Entry = CmosAccessLibLocateEntry (Address);
+
+  if (!CmosAccessLibIsAccessible (Address, Entry)) {
+    return;
+  }
+
+  OriginalData = CmosRead8 (Address);
+
+  CmosAccessLibICmosWrite8 (Address, Data);
+
+  if (CmosAccessLibNeedChecksum (Address, Entry)) {
+    //
+    // Sum of Data + Checksum = New Sum of Data + New Checksum = 0
+    // New Sum of Data - Sum of Data = Checksum - New Checksum
+    // New Checksum = Checksum - (New Sum of Data - Sum of Data)
+    //
+    CmosAccessLibGetChecksumLocation (&ChecksumLocation);
+    CmosAccessLibWriteChecksum (
+      &ChecksumLocation,
+      CmosAccessLibReadChecksum (&ChecksumLocation) - (Data - OriginalData)
+      );
+  }
+}
+
+/**
+  Read a word value from a CMOS address.
+
+  @param [in] Address   Location to read from CMOS
+
+  @return The word value read from the CMOS address.
+**/
+UINT16
+EFIAPI
+CmosRead16 (
+  IN  UINT8  Address
+  )
+{
+  return CmosRead8 (Address) + (CmosRead8 (Address + 1) << 8);
+}
+
+/**
+  Write a word value to a CMOS address.
+
+  @param [in] Address Location to write to CMOS.
+  @param [in] Data    The word value write to the CMOS address.
+**/
+VOID
+EFIAPI
+CmosWrite16 (
+  IN UINT8  Address,
+  IN UINT16 Data
+  )
+{
+  CmosWrite8 (Address, (UINT8) Data);
+  CmosWrite8 (Address + 1, (UINT8) (Data >> 8));
+}
+
+/**
+  Read a dword value from a CMOS address.
+
+  @param [in] Address   Location to read from CMOS
+
+  @return The dword value read from the CMOS address.
+**/
+UINT32
+EFIAPI
+CmosRead32 (
+  IN  UINT8  Address
+  )
+{
+  return CmosRead16 (Address) + (CmosRead16 (Address + 2) << 16);
+}
+
+/**
+  Write a dword value to a CMOS address.
+
+  @param [in] Address Location to write to CMOS.
+  @param [in] Data    The dword value write to the CMOS address.
+**/
+VOID
+EFIAPI
+CmosWrite32 (
+  IN UINT8  Address,
+  IN UINT32 Data
+  )
+{
+  CmosWrite16 (Address, (UINT16) Data);
+  CmosWrite16 (Address + 2, (UINT16) (Data >> 16));
+}
+
+
+/**
+  Initialize the CMOS.
+
+  It initialize the CMOS area when Force is TRUE or the checksum is incorrect.
+
+  @param[in]  Force  TRUE indicating initializing the CMOS area without checking the checksum.
+
+  @retval TRUE  The CMOS is initialized to default value.
+  @retval FALSE The CMOS isn't initialized to default value.
+**/
+BOOLEAN
+EFIAPI
+CmosInit (
+  IN  BOOLEAN     Force
+  )
+{
+  UINTN                       Address;
+  CMOS_ENTRY                  *Entry;
+  CMOS_CHECKSUM_LOCATION_INFO ChecksumLocation;
+  UINT16                      Checksum;
+
+  CmosAccessLibGetChecksumLocation (&ChecksumLocation);
+
+  if (!Force) {
+    //
+    // Initialize the CMOS area when checksum is incorrect.
+    //
+    Checksum = CmosAccessLibCalculateSum (&ChecksumLocation) + CmosAccessLibReadChecksum (&ChecksumLocation);
+    if (ChecksumLocation.Length == 1) {
+      Checksum = (UINT8) Checksum;
+    }
+
+    if (Checksum != 0) {
+      Force = TRUE;
+    }
+  }
+
+  if (Force) {
+    //
+    // Traverse through entire CMOS location and fill it with zero
+    //
+    for (Address = 0; Address <= CMOS_BANK1_LIMIT; Address++) {
+      Entry = CmosAccessLibLocateEntry ((UINT8) Address);
+      if (CmosAccessLibNeedFillDefault ((UINT8) Address, Entry)) {
+        CmosAccessLibICmosWrite8 ((UINT8) Address, (Entry == NULL) ? CMOS_DEFAULT_VALUE : Entry->DefaultValue);
+      }
+    }
+
+    //
+    // Write the New checksum to the Checksum field
+    //
+    CmosAccessLibWriteChecksum (
+      &ChecksumLocation,
+      (UINT16) (0x10000 - CmosAccessLibCalculateSum (&ChecksumLocation))
+      );
+    return TRUE;
+  }
+
+  return FALSE;
+}

--- a/BoardModulePkg/Library/CmosAccessLib/CmosAccessLib.inf
+++ b/BoardModulePkg/Library/CmosAccessLib/CmosAccessLib.inf
@@ -1,0 +1,28 @@
+### @file
+# Library producing CMOS access functionality.
+#
+# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = CmosAccessLib
+  FILE_GUID      = FF6B645D-C001-4ACE-9CA1-199F97C2D601
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = BASE
+  LIBRARY_CLASS  = CmosAccessLib
+
+[Sources]
+  CmosAccessLib.c
+  CmosAccessLibInternal.h
+
+[LibraryClasses]
+  IoLib
+  DebugLib
+  PlatformCmosAccessLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BoardModulePkg/BoardModulePkg.dec

--- a/BoardModulePkg/Library/CmosAccessLib/CmosAccessLibInternal.h
+++ b/BoardModulePkg/Library/CmosAccessLib/CmosAccessLibInternal.h
@@ -1,0 +1,35 @@
+/** @file
+  CmosAccessLib internal header file.
+
+Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _CMOS_ACCESS_LIB_INTERNALS_
+#define _CMOS_ACCESS_LIB_INTERNALS_
+
+#include <Base.h>
+#include <Uefi.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <Library/CmosAccessLib.h>
+#include <Library/PlatformCmosAccessLib.h>
+
+// CMOS access Port address
+
+#define PORT_70            0x70
+#define PORT_71            0x71
+#define PORT_72            0x72
+#define PORT_73            0x73
+
+#define CMOS_BANK0_LIMIT   0x7F
+#define CMOS_BANK1_LIMIT   0xFF
+
+typedef struct {
+   UINT8  Length;
+   UINT8  LowByteAddress;
+   UINT8  HighByteAddress;
+} CMOS_CHECKSUM_LOCATION_INFO;
+
+#endif // _CMOS_ACCESS_LIB_INTERNALS_

--- a/BoardModulePkg/Library/PlatformCmosAccessLibNull/PlatformCmosAccessLibNull.c
+++ b/BoardModulePkg/Library/PlatformCmosAccessLibNull/PlatformCmosAccessLibNull.c
@@ -1,0 +1,39 @@
+/** @file
+  Platform CMOS Access Library.
+
+Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/PlatformCmosAccessLib.h>
+
+/**
+  Return the platform CMOS entries.
+
+  @param [out] EntryCount Return the count of platform CMOS entries.
+
+  @return Platform CMOS entries.
+**/
+CMOS_ENTRY *
+EFIAPI
+PlatformCmosGetEntry (
+  OUT UINTN       *EntryCount
+  )
+{
+  *EntryCount = 0;
+  return NULL;
+}
+
+/**
+  Return the NMI enable status.
+**/
+BOOLEAN
+EFIAPI
+PlatformCmosGetNmiState (
+  VOID
+  )
+{
+  return FALSE;
+}

--- a/BoardModulePkg/Library/PlatformCmosAccessLibNull/PlatformCmosAccessLibNull.inf
+++ b/BoardModulePkg/Library/PlatformCmosAccessLibNull/PlatformCmosAccessLibNull.inf
@@ -1,0 +1,23 @@
+### @file
+# Library producing CMOS access functionalities are relevant to platform.
+#
+# Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = PlatformCmosAccessLib
+  FILE_GUID      = C315A8B6-FF6C-41D1-A934-7330501F308C
+  VERSION_STRING = 1.0
+  MODULE_TYPE    = BASE
+  LIBRARY_CLASS  = PlatformCmosAccessLib
+
+
+[Sources]
+  PlatformCmosAccessLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BoardModulePkg/BoardModulePkg.dec


### PR DESCRIPTION
## Description

Added a modified BoardModulePkg. Modified to remove all the Sio, FirmwareBootMedia, BoardBdsHook modules.

Pkg only includes BiosIdLibs and Cmos/PlatformCmos access libraries.

Added BoardModulePkg.ci.yaml and added BoardModulePkg to CISettings.py.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ran through CI testing.

## Integration Instructions
N/A