### PR TITLE
Updated DxeCheckMemoryMap.c to account for PEI memory buckets

### DIFF
--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckMemoryMap.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/DxeCheckMemoryMap.c
@@ -131,22 +131,22 @@ TestPointCheckUefiMemoryMapEntry (
     }
     Entry = NEXT_MEMORY_DESCRIPTOR (Entry, DescriptorSize);
   }
-  if (EntryCount[EfiRuntimeServicesCode] > 1) {
+  if (EntryCount[EfiRuntimeServicesCode] > 2) {
     DEBUG ((DEBUG_ERROR, "EfiRuntimeServicesCode entry - %d\n", EntryCount[EfiRuntimeServicesCode]));
   }
-  if (EntryCount[EfiRuntimeServicesData] > 1) {
+  if (EntryCount[EfiRuntimeServicesData] > 2) {
     DEBUG ((DEBUG_ERROR, "EfiRuntimeServicesData entry - %d\n", EntryCount[EfiRuntimeServicesData]));
   }
-  if (EntryCount[EfiACPIMemoryNVS] > 1) {
+  if (EntryCount[EfiACPIMemoryNVS] > 2) {
     DEBUG ((DEBUG_ERROR, "EfiACPIMemoryNVS entry - %d\n", EntryCount[EfiACPIMemoryNVS]));
   }
-  if (EntryCount[EfiACPIReclaimMemory] > 1) {
+  if (EntryCount[EfiACPIReclaimMemory] > 2) {
     DEBUG ((DEBUG_ERROR, "EfiACPIReclaimMemory entry - %d\n", EntryCount[EfiACPIReclaimMemory]));
   }
-  if ((EntryCount[EfiRuntimeServicesCode] > 1) ||
-      (EntryCount[EfiRuntimeServicesData] > 1) ||
-      (EntryCount[EfiACPIReclaimMemory] > 1) ||
-      (EntryCount[EfiACPIMemoryNVS] > 1) ) {
+  if ((EntryCount[EfiRuntimeServicesCode] > 2) ||
+      (EntryCount[EfiRuntimeServicesData] > 2) ||
+      (EntryCount[EfiACPIReclaimMemory] > 2) ||
+      (EntryCount[EfiACPIMemoryNVS] > 2) ) {
     return FALSE;
   } else {
     return TRUE;


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Updates the memory map testpoint test to fail if there are more than 2 areas of each runtime memory type instead of 1.  This accounts for PEI and DXE memory buckets.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ran the test with the change with the new PEI memory buckets and the test passes now.

## Integration Instructions

N/A
