### PR TITLE
Add a new check for the MmPageProtection test.

### DIFF
--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/MmTestPointCheckLib.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/MmTestPointCheckLib.c
@@ -62,6 +62,12 @@ TestPointMmReadyToBootMmPageProtection (
   )
 {
   EFI_STATUS Status;
+
+  if ((mFeatureImplemented[TEST_POINT_INDEX_BYTE6_SMM]
+    & TEST_POINT_BYTE6_SMM_READY_TO_BOOT_SMM_PAGE_LEVEL_PROTECTION) == 0) {
+    return EFI_SUCCESS;
+  }
+
   DEBUG ((DEBUG_INFO, "======== TestPointMmReadyToBootMmPageProtection - Enter\n"));
   Status = TestPointReadyToBootMmPageProtection ();
   DEBUG ((DEBUG_INFO, "======== TestPointMmReadyToBootMmPageProtection - Enter\n"));


### PR DESCRIPTION
## Description

There's a bug where the Ready to Boot MmPageProtection tests  run even we indicate there isn't supported functionality for the features tested.  This adds a check so that doesn't happen.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Build and booted QemuQ35 with the feature implemented bit disabled.  Confirmed that with the current top of release/202302 the test runs and with the change the test doesn't.

## Integration Instructions

N/A