### PR TITLE
Removed references to openssllib and it's associated libraries

### DIFF
--- a/MinPlatformPkg/Include/Dsc/CoreCommonLib.dsc
+++ b/MinPlatformPkg/Include/Dsc/CoreCommonLib.dsc
@@ -151,6 +151,11 @@
   #
   # CryptLib
   #
+
+  # MU_CHANGE - Remove Openssl crypto references
+  #IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
+  #OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf
+
   RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
 
   Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12DeviceLibDTpm.inf

--- a/MinPlatformPkg/Include/Dsc/CoreCommonLib.dsc
+++ b/MinPlatformPkg/Include/Dsc/CoreCommonLib.dsc
@@ -151,9 +151,6 @@
   #
   # CryptLib
   #
-  IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
-  OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf
-
   RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
 
   Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12DeviceLibDTpm.inf

--- a/MinPlatformPkg/Include/Dsc/CoreDxeLib.dsc
+++ b/MinPlatformPkg/Include/Dsc/CoreDxeLib.dsc
@@ -34,6 +34,8 @@
 
   TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
 
+  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf  MU_CHANGE - Remove Openssl crypto references
+
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
   HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
   Tcg2PhysicalPresenceLib|SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
@@ -86,7 +88,8 @@
   SmmCpuFeaturesLib|UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
 
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
-  Tcg2PhysicalPresenceLib|SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/SmmTcg2PhysicalPresenceLib.inf
+  Tcg2PhysicalPresenceLib|SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/SmmTcg2PhysicalPresenceLib.
+  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf  MU_CHANGE - Remove Openssl crypto reference
   VariableReadLib|MinPlatformPkg/Library/SmmVariableReadLib/TraditionalMmVariableReadLib.inf
   VariableWriteLib|MinPlatformPkg/Library/SmmVariableWriteLib/TraditionalMmVariableWriteLib.inf
 
@@ -102,6 +105,7 @@
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   ReportStatusCodeLib|MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/RuntimeDxeReportStatusCodeLib.inf
+  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf  MU_CHANGE - Remove Openssl crypto reference
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLibRuntimeDxe.inf
 
 [LibraryClasses.common.UEFI_APPLICATION]

--- a/MinPlatformPkg/Include/Dsc/CoreDxeLib.dsc
+++ b/MinPlatformPkg/Include/Dsc/CoreDxeLib.dsc
@@ -34,8 +34,6 @@
 
   TpmMeasurementLib|SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
 
-  BaseCryptLib|CryptoPkg/Library/BaseCryptLib/BaseCryptLib.inf
-
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterDxe.inf
   HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
   Tcg2PhysicalPresenceLib|SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf
@@ -89,7 +87,6 @@
 
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
   Tcg2PhysicalPresenceLib|SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/SmmTcg2PhysicalPresenceLib.inf
-  BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf
   VariableReadLib|MinPlatformPkg/Library/SmmVariableReadLib/TraditionalMmVariableReadLib.inf
   VariableWriteLib|MinPlatformPkg/Library/SmmVariableWriteLib/TraditionalMmVariableWriteLib.inf
 
@@ -105,7 +102,6 @@
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   ReportStatusCodeLib|MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/RuntimeDxeReportStatusCodeLib.inf
-  BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLibRuntimeDxe.inf
 
 [LibraryClasses.common.UEFI_APPLICATION]

--- a/MinPlatformPkg/Include/Dsc/CoreDxeLib.dsc
+++ b/MinPlatformPkg/Include/Dsc/CoreDxeLib.dsc
@@ -88,7 +88,7 @@
   SmmCpuFeaturesLib|UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
 
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
-  Tcg2PhysicalPresenceLib|SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/SmmTcg2PhysicalPresenceLib.
+  Tcg2PhysicalPresenceLib|SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/SmmTcg2PhysicalPresenceLib.inf
   #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf  MU_CHANGE - Remove Openssl crypto references
   VariableReadLib|MinPlatformPkg/Library/SmmVariableReadLib/TraditionalMmVariableReadLib.inf
   VariableWriteLib|MinPlatformPkg/Library/SmmVariableWriteLib/TraditionalMmVariableWriteLib.inf

--- a/MinPlatformPkg/Include/Dsc/CoreDxeLib.dsc
+++ b/MinPlatformPkg/Include/Dsc/CoreDxeLib.dsc
@@ -89,7 +89,7 @@
 
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
   Tcg2PhysicalPresenceLib|SecurityPkg/Library/SmmTcg2PhysicalPresenceLib/SmmTcg2PhysicalPresenceLib.
-  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf  MU_CHANGE - Remove Openssl crypto reference
+  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/SmmCryptLib.inf  MU_CHANGE - Remove Openssl crypto references
   VariableReadLib|MinPlatformPkg/Library/SmmVariableReadLib/TraditionalMmVariableReadLib.inf
   VariableWriteLib|MinPlatformPkg/Library/SmmVariableWriteLib/TraditionalMmVariableWriteLib.inf
 
@@ -105,7 +105,7 @@
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   ReportStatusCodeLib|MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/RuntimeDxeReportStatusCodeLib.inf
-  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf  MU_CHANGE - Remove Openssl crypto reference
+  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/RuntimeCryptLib.inf  MU_CHANGE - Remove Openssl crypto references
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLibRuntimeDxe.inf
 
 [LibraryClasses.common.UEFI_APPLICATION]

--- a/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
+++ b/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
@@ -47,7 +47,7 @@
   TimerLib|PcAtChipsetPkg/Library/AcpiTimerLib/PeiAcpiTimerLib.inf
 
 [LibraryClasses.common.PEIM]
-  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf  MU_CHANGE - Remove Openssl crypto reference
+  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf  MU_CHANGE - Remove Openssl crypto references
 
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterPei.inf
   HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.inf

--- a/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
+++ b/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
@@ -47,8 +47,6 @@
   TimerLib|PcAtChipsetPkg/Library/AcpiTimerLib/PeiAcpiTimerLib.inf
 
 [LibraryClasses.common.PEIM]
-  BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf
-
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterPei.inf
   HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.inf
   Tcg2PhysicalPresenceLib|SecurityPkg/Library/PeiTcg2PhysicalPresenceLib/PeiTcg2PhysicalPresenceLib.inf

--- a/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
+++ b/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
@@ -47,6 +47,8 @@
   TimerLib|PcAtChipsetPkg/Library/AcpiTimerLib/PeiAcpiTimerLib.inf
 
 [LibraryClasses.common.PEIM]
+  #BaseCryptLib|CryptoPkg/Library/BaseCryptLib/PeiCryptLib.inf  MU_CHANGE - Remove Openssl crypto reference
+
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibRouter/Tpm2DeviceLibRouterPei.inf
   HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.inf
   Tcg2PhysicalPresenceLib|SecurityPkg/Library/PeiTcg2PhysicalPresenceLib/PeiTcg2PhysicalPresenceLib.inf


### PR DESCRIPTION
## Description

There are some references to BaseCryptLib and Openssl in package dsc files. In MU_BASECORE Openssl and its BaseCryptLib implementations were removed so we need to update to using the NULL lib.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested with CI

## Integration Instructions

N/A