### PR TITLE
MinPlatformPkg SerialPortTerminalLib: Fixing CodeQL issue Pointless comparison of unsigned value to zero.

### DIFF
--- a/MinPlatformPkg/Library/SerialPortTerminalLib/SerialPortTerminalLib.c
+++ b/MinPlatformPkg/Library/SerialPortTerminalLib/SerialPortTerminalLib.c
@@ -88,8 +88,7 @@ AddSerialTerminal (
       (int) mSerialDevicePath.Uart.StopBits,
       (int) DefaultTerminalType));
 
-  if (DefaultTerminalType >= 0 &&
-      DefaultTerminalType < (sizeof (mTerminalType) / sizeof (mTerminalType[0]))) {
+  if (DefaultTerminalType < (sizeof (mTerminalType) / sizeof (mTerminalType[0]))) {
     CopyMem (
       (VOID *) &(mSerialDevicePath.TerminalType.Guid),
       (VOID *) mTerminalType[DefaultTerminalType],


### PR DESCRIPTION
## Description

CodeQL is reporting Pointless comparison of unsigned value to zero for a value derived from an unsigned PCD PcdDefaultTerminalType.


- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Ran Local CI.

## Integration Instructions
N/A