### PR TITLE
Make PlatformInitPreMem independent to IntelSiliconPkg and IntelFsp2WrapperPkg

### DIFF
--- a/MinPlatformPkg/MinPlatformPkg.dsc
+++ b/MinPlatformPkg/MinPlatformPkg.dsc
@@ -190,9 +190,7 @@
 
   MinPlatformPkg/PlatformInit/ReportFv/ReportFvPei.inf
   MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.inf
-  # MU_CHANGE [BEGIN] For MU repo pipeline requirement
   MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
-  # MU_CHANGE [END]
   MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPostMem.inf
   MinPlatformPkg/PlatformInit/PlatformInitDxe/PlatformInitDxe.inf
   MinPlatformPkg/PlatformInit/PlatformInitSmm/PlatformInitSmm.inf

--- a/MinPlatformPkg/MinPlatformPkg.dsc
+++ b/MinPlatformPkg/MinPlatformPkg.dsc
@@ -190,6 +190,9 @@
 
   MinPlatformPkg/PlatformInit/ReportFv/ReportFvPei.inf
   MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.inf
+  # MU_CHANGE [BEGIN] For MU repo pipeline requirement
+  MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
+  # MU_CHANGE [END]
   MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPostMem.inf
   MinPlatformPkg/PlatformInit/PlatformInitDxe/PlatformInitDxe.inf
   MinPlatformPkg/PlatformInit/PlatformInitSmm/PlatformInitSmm.inf

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupport.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupport.c
@@ -1,0 +1,10 @@
+#include <PiPei.h>
+
+UINT8
+EFIAPI
+FspGetModeSelection (
+  VOID
+  )
+{
+  return PcdGet8 (PcdFspModeSelection);
+}

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupport.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupport.c
@@ -1,3 +1,10 @@
+/** @file FspSupport.c
+  Provides FSP mode selection value based on PcdFspModeSelection
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
 #include <PiPei.h>
 
 UINT8

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupportNull.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupportNull.c
@@ -1,0 +1,10 @@
+#include <PiPei.h>
+
+UINT8
+EFIAPI
+FspGetModeSelection (
+  VOID
+  )
+{
+  return 0;
+}

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupportNull.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupportNull.c
@@ -1,3 +1,10 @@
+/** @file FspSupport.c
+  Provides FSP mode selection value based on PcdFspModeSelection
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
 #include <PiPei.h>
 
 UINT8

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
@@ -51,7 +51,7 @@ UINT8
 EFIAPI
 FspGetModeSelection (
   VOID
-);
+  );
 
 /**
 

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
@@ -522,7 +522,7 @@ PlatformInitPreMem (
 
   BuildMemoryTypeInformation ();
 
-  if ((!PcdGetBool (PcdFspWrapperBootMode)) || (FspGetModeSelection() == 0)) {
+  if ((!PcdGetBool (PcdFspWrapperBootMode)) || (FspGetModeSelection () == 0)) {
     //
     // Install memory relating PPIs for EDKII native build and FSP dispatch mode
     //

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
@@ -47,6 +47,12 @@ GetPlatformMemorySize (
   IN OUT  UINT64                                 *MemorySize
   );
 
+UINT8
+EFIAPI
+FspGetModeSelection (
+  VOID
+);
+
 /**
 
   This function checks the memory range in PEI.
@@ -516,7 +522,7 @@ PlatformInitPreMem (
 
   BuildMemoryTypeInformation ();
 
-  if ((!PcdGetBool (PcdFspWrapperBootMode)) || (PcdGet8 (PcdFspModeSelection) == 0)) {
+  if ((!PcdGetBool (PcdFspWrapperBootMode)) || (FspGetModeSelection() == 0)) {
     //
     // Install memory relating PPIs for EDKII native build and FSP dispatch mode
     //

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
@@ -2,6 +2,7 @@
 # Component information file for the Platform Init Pre-Memory PEI module.
 #
 # Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
@@ -9,8 +9,8 @@
 
 [Defines]
   INF_VERSION                    = 0x00010017
-  BASE_NAME                      = PlatformInitPreMem
-  FILE_GUID                      = EEEE611D-F78F-4FB9-B868-55907F169280
+  BASE_NAME                      = PlatformInitPreMemNonFsp
+  FILE_GUID                      = BEB6F1A6-F6BC-4C34-AB32-F0390A428479
   VERSION_STRING                 = 1.0
   MODULE_TYPE                    = PEIM
   ENTRY_POINT                    = PlatformInitPreMemEntryPoint
@@ -33,14 +33,11 @@
   MinPlatformPkg/MinPlatformPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
-  IntelSiliconPkg/IntelSiliconPkg.dec
-  IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
 
 [Pcd]
   gMinPlatformPkgTokenSpaceGuid.PcdFspWrapperBootMode          ## CONSUMES
   gMinPlatformPkgTokenSpaceGuid.PcdStopAfterDebugInit          ## CONSUMES
   gMinPlatformPkgTokenSpaceGuid.PcdStopAfterMemInit            ## CONSUMES
-  gIntelFsp2WrapperTokenSpaceGuid.PcdFspModeSelection          ## CONSUMES
 
 [FixedPcd]
   gMinPlatformPkgTokenSpaceGuid.PcdPlatformEfiAcpiReclaimMemorySize  ## CONSUMES
@@ -51,7 +48,7 @@
 
 [Sources]
   PlatformInitPreMem.c
-  FspSupport.c
+  FspSupportNull.c
 
 [Ppis]
   gEfiPeiMemoryDiscoveredPpiGuid


### PR DESCRIPTION
## Description

This driver is shared across different Silicon vendors. So it should not use any Intel specific packages.

In order to achieve this, added a new lib `FspSupportLib` to isolate silicon related PCDs

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI build passed.

## Integration Instructions

No additional change is required for the consuming platforms.