### PR TITLE
[CHERRY-PICK] BoardModulePkg: Added Mock library for BiosIdLib

### DIFF
--- a/BoardModulePkg/BoardModulePkg.dec
+++ b/BoardModulePkg/BoardModulePkg.dec
@@ -22,6 +22,7 @@
 
 [Includes]
   Include
+  Test/Mock/Include
 
 [LibraryClasses]
   ##  @libraryclass    Provide services to access CMOS area.

--- a/BoardModulePkg/Test/BoardModulePkgHostTest.dsc
+++ b/BoardModulePkg/Test/BoardModulePkgHostTest.dsc
@@ -1,0 +1,32 @@
+## @file BoardModulePkgHostTest.dsc
+#
+#  BoardModulePkg DSC file used to build host-based unit tests.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  PLATFORM_NAME           = BoardModulePkgHostTest
+  PLATFORM_GUID           = 67275336-A324-4F69-BD38-70A4C7898F06
+  PLATFORM_VERSION        = 0.1
+  DSC_SPECIFICATION       = 0x00010005
+  OUTPUT_DIRECTORY        = Build/BoardModulePkg/HostTest
+  SUPPORTED_ARCHITECTURES = IA32|X64
+  BUILD_TARGETS           = NOOPT
+  SKUID_IDENTIFIER        = DEFAULT
+
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+
+[LibraryClasses]
+
+[Components]
+  #
+  # Build HOST_APPLICATIONs that test the BoardModulePkg
+  #
+
+  #
+  # Build HOST_APPLICATION Libraries With GoogleTest
+  #
+  BoardModulePkg/Test/Mock/Library/GoogleTest/MockBiosIdLib/MockBiosIdLib.inf

--- a/BoardModulePkg/Test/Mock/Include/GoogleTest/Library/MockBiosIdLib.h
+++ b/BoardModulePkg/Test/Mock/Include/GoogleTest/Library/MockBiosIdLib.h
@@ -1,0 +1,41 @@
+/** @file MockBiosIdLib.h
+  Google Test mocks for BiosIdLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_BIOS_ID_LIB_H_
+#define MOCK_BIOS_ID_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Pi/PiBootMode.h>
+  #include <Library/BiosIdLib.h>
+}
+
+struct MockBiosIdLib {
+  MOCK_INTERFACE_DECLARATION (MockBiosIdLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetBiosId,
+    (
+     OUT BIOS_ID_IMAGE     *BiosIdImage OPTIONAL
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetBiosVersionDateTime,
+    (
+     OUT CHAR16    *BiosVersion, OPTIONAL
+     OUT CHAR16    *BiosReleaseDate, OPTIONAL
+     OUT CHAR16    *BiosReleaseTime OPTIONAL
+    )
+    );
+};
+
+#endif

--- a/BoardModulePkg/Test/Mock/Library/GoogleTest/MockBiosIdLib/MockBiosIdLib.cpp
+++ b/BoardModulePkg/Test/Mock/Library/GoogleTest/MockBiosIdLib/MockBiosIdLib.cpp
@@ -1,0 +1,12 @@
+/** @file MockBiosIdLib.cpp
+  Google Test mocks for BiosIdLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockBiosIdLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockBiosIdLib);
+MOCK_FUNCTION_DEFINITION (MockBiosIdLib, GetBiosId, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBiosIdLib, GetBiosVersionDateTime, 3, EFIAPI);

--- a/BoardModulePkg/Test/Mock/Library/GoogleTest/MockBiosIdLib/MockBiosIdLib.inf
+++ b/BoardModulePkg/Test/Mock/Library/GoogleTest/MockBiosIdLib/MockBiosIdLib.inf
@@ -1,0 +1,33 @@
+## @file MockBiosIdLib.inf
+# Google Test mock for BiosIdLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockBiosIdLib
+  FILE_GUID                      = FD03FA6D-7447-499C-B3AF-D89450F7739A
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BiosIdLib
+  PI_SPECIFICATION_VERSION       = 0x0001000A
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockBiosIdLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  BoardModulePkg/BoardModulePkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc


### PR DESCRIPTION
## Description
Added a gmock for GoogleTests that pull in BiosIdLib.

Cherry picked from edk2_platforms
[c53db4dc8bbc6cec6016792b9e08b1f0630498ae](https://github.com/tianocore/edk2-platforms/commit/c53db4dc8bbc6cec6016792b9e08b1f0630498ae)
Amended to add newline in header file description.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Consumed mock in GoogleTest

## Integration Instructions
N/A
