### PR TITLE
Make PlatformInitPreMem independent to IntelSiliconPkg and IntelFsp2WrapperPkg

### DIFF
--- a/MinPlatformPkg/MinPlatformPkg.dsc
+++ b/MinPlatformPkg/MinPlatformPkg.dsc
@@ -190,6 +190,7 @@
 
   MinPlatformPkg/PlatformInit/ReportFv/ReportFvPei.inf
   MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.inf
+  MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
   MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPostMem.inf
   MinPlatformPkg/PlatformInit/PlatformInitDxe/PlatformInitDxe.inf
   MinPlatformPkg/PlatformInit/PlatformInitSmm/PlatformInitSmm.inf

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupport.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupport.c
@@ -1,0 +1,17 @@
+/** @file FspSupport.c
+  Provides FSP mode selection value based on PcdFspModeSelection
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiPei.h>
+
+UINT8
+EFIAPI
+FspGetModeSelection (
+  VOID
+  )
+{
+  return PcdGet8 (PcdFspModeSelection);
+}

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupportNull.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/FspSupportNull.c
@@ -1,0 +1,17 @@
+/** @file FspSupport.c
+  Provides FSP mode selection value based on PcdFspModeSelection
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiPei.h>
+
+UINT8
+EFIAPI
+FspGetModeSelection (
+  VOID
+  )
+{
+  return 0;
+}

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMem.c
@@ -47,6 +47,12 @@ GetPlatformMemorySize (
   IN OUT  UINT64                                 *MemorySize
   );
 
+UINT8
+EFIAPI
+FspGetModeSelection (
+  VOID
+  );
+
 /**
 
   This function checks the memory range in PEI.
@@ -516,7 +522,7 @@ PlatformInitPreMem (
 
   BuildMemoryTypeInformation ();
 
-  if ((!PcdGetBool (PcdFspWrapperBootMode)) || (PcdGet8 (PcdFspModeSelection) == 0)) {
+  if ((!PcdGetBool (PcdFspWrapperBootMode)) || (FspGetModeSelection () == 0)) {
     //
     // Install memory relating PPIs for EDKII native build and FSP dispatch mode
     //

--- a/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
+++ b/MinPlatformPkg/PlatformInit/PlatformInitPei/PlatformInitPreMemNonFsp.inf
@@ -2,6 +2,7 @@
 # Component information file for the Platform Init Pre-Memory PEI module.
 #
 # Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -9,8 +10,8 @@
 
 [Defines]
   INF_VERSION                    = 0x00010017
-  BASE_NAME                      = PlatformInitPreMem
-  FILE_GUID                      = EEEE611D-F78F-4FB9-B868-55907F169280
+  BASE_NAME                      = PlatformInitPreMemNonFsp
+  FILE_GUID                      = BEB6F1A6-F6BC-4C34-AB32-F0390A428479
   VERSION_STRING                 = 1.0
   MODULE_TYPE                    = PEIM
   ENTRY_POINT                    = PlatformInitPreMemEntryPoint
@@ -33,14 +34,11 @@
   MinPlatformPkg/MinPlatformPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
-  IntelSiliconPkg/IntelSiliconPkg.dec
-  IntelFsp2WrapperPkg/IntelFsp2WrapperPkg.dec
 
 [Pcd]
   gMinPlatformPkgTokenSpaceGuid.PcdFspWrapperBootMode          ## CONSUMES
   gMinPlatformPkgTokenSpaceGuid.PcdStopAfterDebugInit          ## CONSUMES
   gMinPlatformPkgTokenSpaceGuid.PcdStopAfterMemInit            ## CONSUMES
-  gIntelFsp2WrapperTokenSpaceGuid.PcdFspModeSelection          ## CONSUMES
 
 [FixedPcd]
   gMinPlatformPkgTokenSpaceGuid.PcdPlatformEfiAcpiReclaimMemorySize  ## CONSUMES
@@ -51,7 +49,7 @@
 
 [Sources]
   PlatformInitPreMem.c
-  FspSupport.c
+  FspSupportNull.c
 
 [Ppis]
   gEfiPeiMemoryDiscoveredPpiGuid


### PR DESCRIPTION
## Description

This driver is shared across different Silicon vendors. So it should not use any Intel specific packages.

In order to achieve this, added a new lib `FspSupportLib` to isolate silicon related PCDs

---

Note: This change targeted the "release" branch in https://github.com/microsoft/mu_common_intel_min_platform/pull/293 before the "dev" branch was created. This adds the commit to the dev branch for parity with the release branch.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI build passed.

## Integration Instructions

No additional change is required for the consuming platforms.