### PR TITLE
MinPlatformPkg SerialPortTerminalLib: Fixing CodeQL issue Pointless c…

### DIFF
--- a/MinPlatformPkg/Library/SerialPortTerminalLib/SerialPortTerminalLib.c
+++ b/MinPlatformPkg/Library/SerialPortTerminalLib/SerialPortTerminalLib.c
@@ -88,8 +88,7 @@ AddSerialTerminal (
       (int) mSerialDevicePath.Uart.StopBits,
       (int) DefaultTerminalType));
 
-  if (DefaultTerminalType >= 0 &&
-      DefaultTerminalType < (sizeof (mTerminalType) / sizeof (mTerminalType[0]))) {
+  if (DefaultTerminalType < (sizeof (mTerminalType) / sizeof (mTerminalType[0]))) {
     CopyMem (
       (VOID *) &(mSerialDevicePath.TerminalType.Guid),
       (VOID *) mTerminalType[DefaultTerminalType],


### PR DESCRIPTION
## Description

Cherry-pick Commit 03664aa #282 from release/202311 to dev/202405.
CodeQL is reporting Pointless comparison of unsigned value to zero for a value derived from an unsigned PCD PcdDefaultTerminalType.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [X] Backport to release branch?

## How This Was Tested

Ran Local CI including codeQL setting and pipeline codeQL build.

## Integration Instructions

N/A

## upstream repo in EDK2?

https://github.com/tianocore/edk2-platforms/pull/246