### PR TITLE
[RB & FF] CI: Limit CI runs to AARCH64, IA32, X64

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -15,7 +15,7 @@
 ##
 
 variables:
-- group: architectures-arm-64-x86-64
+- group: architectures-arm64-x86-64
 - group: tool-chain-ubuntu-gcc
 - group: coverage
 

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -179,13 +179,15 @@ class Settings(CiSetupSettingsManager, CiBuildSettingsManager, UpdateSettingsMan
             Branch: <optional> Branch to checkout (will checkout most recent commit in branch)
             Full: <optional> Boolean to do shallow or Full checkout.  (default is False)
             ReferencePath: <optional> Workspace relative path to git repo to use as "reference"
+            Recurse: <optional> Specifies if Dependency shoudl be recursively cloned.
         }
         '''
         return [
             {
                 "Path": "Common/MU_TIANO",
                 "Url": "https://github.com/microsoft/mu_tiano_plus.git",
-                "Branch": "dev/202502"
+                "Branch": "dev/202502",
+                "Recurse" : {"CIFile": ".pytool/CISettings.py"},
             },
             {
                 "Path": "MU_BASECORE",

--- a/MinPlatformPkg/MinPlatformPkg.dsc
+++ b/MinPlatformPkg/MinPlatformPkg.dsc
@@ -121,6 +121,7 @@
   TestPointCheckLib|MinPlatformPkg/Test/Library/TestPointCheckLib/StandaloneMmTestPointCheckLib.inf
   TestPointLib|MinPlatformPkg/Test/Library/TestPointLib/StandaloneMmTestPointLib.inf
   MemLib|StandaloneMmPkg/Library/StandaloneMmMemLib/StandaloneMmMemLib.inf
+  DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLibBase.inf # MU_CHANGE - Use Base version to prevent gBS inclusion
 
 ###################################################################################################
 #

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,8 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library==0.22.5
-edk2-pytool-extensions==0.28.0
+edk2-pytool-library==0.23.2
+edk2-pytool-extensions==0.29.3
 antlr4-python3-runtime==4.13.2
 regex==2024.11.6
 pygount==1.8.0


### PR DESCRIPTION
## Description
Remove ARM as a target for CI runs.

Only target AARCH64, IA32, X64 for GCC CI.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
Local CI builds. 

## Integration Instructions
Not Applicable since it is a CI change. 