### PR TITLE
[CHERRY-PICK] Remove unnecessary packages

### DIFF
--- a/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLib.c
+++ b/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLib.c
@@ -6,7 +6,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include <PiDxe.h>
-#include <Library/BoardInitLib.h>
 #include <Library/PcdLib.h>
 
 EFI_STATUS

--- a/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLib.c
+++ b/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLib.c
@@ -5,8 +5,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#include <PiDxe.h>
-#include <Library/PcdLib.h>
+#include <Uefi.h>
 
 EFI_STATUS
 EFIAPI

--- a/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLibNull.inf
+++ b/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLibNull.inf
@@ -25,7 +25,6 @@
   MdePkg/MdePkg.dec
 
 [LibraryClasses]
-  BaseLib
 
 [Guids]
 

--- a/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLibNull.inf
+++ b/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLibNull.inf
@@ -22,9 +22,7 @@
   SecBoardInitLib.c
 
 [Packages]
-  MinPlatformPkg/MinPlatformPkg.dec
   MdePkg/MdePkg.dec
-  IntelFsp2Pkg/IntelFsp2Pkg.dec
 
 [LibraryClasses]
   BaseLib


### PR DESCRIPTION
## Description

SecBoardInitLibNull does not requires any package except MdePkg.dec

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Build passed in project that does not have IntelFsp2Pkg

## Integration Instructions

N/A