### PR TITLE
[CHERRY-PICK] MinPlatformPkg: Skip FSP libraries for non FSP build

### DIFF
--- a/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
+++ b/MinPlatformPkg/Include/Dsc/CorePeiLib.dsc
@@ -52,9 +52,11 @@
   Tcg2PhysicalPresenceLib|SecurityPkg/Library/PeiTcg2PhysicalPresenceLib/PeiTcg2PhysicalPresenceLib.inf
   TpmPlatformHierarchyLib|SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
 
+!if gMinPlatformPkgTokenSpaceGuid.PcdFspWrapperBootMode == TRUE
   FspMeasurementLib|IntelFsp2WrapperPkg/Library/BaseFspMeasurementLib/BaseFspMeasurementLib.inf
   FspWrapperPlatformMultiPhaseLib|IntelFsp2WrapperPkg/Library/BaseFspWrapperPlatformMultiPhaseLibNull/BaseFspWrapperPlatformMultiPhaseLibNull.inf
   FspWrapperMultiPhaseProcessLib|IntelFsp2WrapperPkg/Library/FspWrapperMultiPhaseProcessLib/FspWrapperMultiPhaseProcessLib.inf
+!endif
   TcgEventLogRecordLib|SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.inf
   TpmMeasurementLib|SecurityPkg/Library/PeiTpmMeasurementLib/PeiTpmMeasurementLib.inf
 

--- a/MinPlatformPkg/Include/Dsc/MinPlatformFeaturesPcd.dsc.inc
+++ b/MinPlatformPkg/Include/Dsc/MinPlatformFeaturesPcd.dsc.inc
@@ -23,3 +23,6 @@
  gMinPlatformPkgTokenSpaceGuid.PcdTpm2Enable                    |FALSE
 
  gMinPlatformPkgTokenSpaceGuid.PcdPerformanceEnable             |FALSE
+
+[PcdsFixedAtBuild]
+ gMinPlatformPkgTokenSpaceGuid.PcdFspWrapperBootMode            |FALSE


### PR DESCRIPTION
## Description

Some platforms consuming MinPlatformPkg does not use FSP architecture. Therefore does not have IntelFsp2WrapperPkg presents.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Build passed in project that does not have IntelFsp2WrapperPkg

## Integration Instructions

N/A