### PR TITLE
[Cherry-pick] Remove unnecessary packages

### DIFF
--- a/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLibNull.inf
+++ b/MinPlatformPkg/PlatformInit/Library/SecBoardInitLibNull/SecBoardInitLibNull.inf
@@ -22,9 +22,7 @@
   SecBoardInitLib.c
 
 [Packages]
-  MinPlatformPkg/MinPlatformPkg.dec
   MdePkg/MdePkg.dec
-  IntelFsp2Pkg/IntelFsp2Pkg.dec
 
 [LibraryClasses]
   BaseLib


### PR DESCRIPTION
SecBoardInitLibNull does not requires any package except MdePkg.dec

(cherry picked from commit c2066dd84c2d727a0605396cdbb467639fc28701)

## Description
Remove the unnecessary packages from SecBoardInitLibNull.

Cherry picked from edk2_platforms [c2066dd84c2d727a0605396cdbb467639fc28701](https://github.com/tianocore/edk2-platforms/commit/c2066dd84c2d727a0605396cdbb467639fc28701)

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI build passed

## Integration Instructions

N/A
