### PR TITLE
MinPlatformPkg: Fix VS 14.44.35207 Build Errors

### DIFF
--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/MmCheckPaging.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/MmCheckPaging.c
@@ -361,7 +361,7 @@ TestPointCheckPageTable (
     }
 
     PageEntryLength = PageAttributeToLength (PageAttribute);
-    PageEntryLength = (UINTN)((BaseAddress & ~(PageEntryLength - 1)) + PageEntryLength - BaseAddress);
+    PageEntryLength = (UINTN)((BaseAddress & ~(EFI_PHYSICAL_ADDRESS)(PageEntryLength - 1)) + PageEntryLength - BaseAddress);
 
     //
     // move to next


### PR DESCRIPTION


## Description

VS 14.44.25207 has increased checking of zero extending values. When building IA32, the UINTN to EFI_PHYSICAL_ADDRESS is being flagged as a C4319 warning. This is highlighting that zero extending may lose the intended behavior.

Add explicit cast to value before inverting the value to suppress the warning message.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local CI build.

## Integration Instructions
No integration necessary.