### PR TITLE
TestPoint: Add pre-boot DMA protection check for Abort DMA Mode

### DIFF
--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/PeiCheckDmaProtection.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/PeiCheckDmaProtection.c
@@ -29,7 +29,9 @@ CheckDrhd (
   INTN                                  DmarLen;
   EFI_ACPI_DMAR_DRHD_HEADER             *Drhd;
   UINT32                                Reg32;
+  UINT64                                Reg64;
   VTD_CAP_REG                           CapReg;
+  VTD_ECAP_REG                          ECapReg;
     
   //
   // Sub table
@@ -41,16 +43,33 @@ CheckDrhd (
     case EFI_ACPI_DMAR_TYPE_DRHD:
       Drhd = (EFI_ACPI_DMAR_DRHD_HEADER *)DmarStructHeader;
 
-      Reg32 = MmioRead32 ((UINTN)Drhd->RegisterBaseAddress + R_GSTS_REG);
+      ECapReg.Uint64 = MmioRead64 ((UINTN)Drhd->RegisterBaseAddress + R_ECAP_REG);
+      if (ECapReg.Bits.ADMS == 1) {
+        Reg64 = MmioRead64 ((UINTN)Drhd->RegisterBaseAddress + R_RTADDR_REG);
+        if (Reg64 != V_RTADDR_REG_TTM_ADM) {
+          DEBUG ((DEBUG_ERROR, "Abort DMA Mode is not enabled\n"));
+          return EFI_INVALID_PARAMETER;
+        }
 
-      CapReg.Uint64 = MmioRead64 ((UINTN)Drhd->RegisterBaseAddress + R_CAP_REG);
-      if (CapReg.Bits.PLMR == 0 || CapReg.Bits.PHMR == 0) {
-        return EFI_INVALID_PARAMETER;
-      }
+        Reg32 = MmioRead32 ((UINTN)Drhd->RegisterBaseAddress + R_GSTS_REG);
+        if ((Reg32 & B_GSTS_REG_TE) == 0) {
+          DEBUG ((DEBUG_ERROR, "DMA remapping is not enabled\n"));
+          return EFI_INVALID_PARAMETER;
+        }
 
-      Reg32 = MmioRead32 ((UINTN)Drhd->RegisterBaseAddress + R_PMEN_ENABLE_REG);
-      if ((Reg32 & BIT0) == 0) {
-        return EFI_INVALID_PARAMETER;
+        DEBUG ((DEBUG_INFO, "DMA remapping is enabled with Abort DMA Mode\n"));
+      } else {
+        Reg32 = MmioRead32 ((UINTN)Drhd->RegisterBaseAddress + R_GSTS_REG);
+
+        CapReg.Uint64 = MmioRead64 ((UINTN)Drhd->RegisterBaseAddress + R_CAP_REG);
+        if (CapReg.Bits.PLMR == 0 || CapReg.Bits.PHMR == 0) {
+          return EFI_INVALID_PARAMETER;
+        }
+
+        Reg32 = MmioRead32 ((UINTN)Drhd->RegisterBaseAddress + R_PMEN_ENABLE_REG);
+        if ((Reg32 & BIT0) == 0) {
+          return EFI_INVALID_PARAMETER;
+        }
       }
 
       break;

--- a/MinPlatformPkg/Test/Library/TestPointCheckLib/PeiCheckDmaProtection.c
+++ b/MinPlatformPkg/Test/Library/TestPointCheckLib/PeiCheckDmaProtection.c
@@ -46,29 +46,27 @@ CheckDrhd (
       ECapReg.Uint64 = MmioRead64 ((UINTN)Drhd->RegisterBaseAddress + R_ECAP_REG);
       if (ECapReg.Bits.ADMS == 1) {
         Reg64 = MmioRead64 ((UINTN)Drhd->RegisterBaseAddress + R_RTADDR_REG);
-        if (Reg64 != V_RTADDR_REG_TTM_ADM) {
+        if ((Reg64 & V_RTADDR_REG_TTM_ADM) != V_RTADDR_REG_TTM_ADM) {
           DEBUG ((DEBUG_ERROR, "Abort DMA Mode is not enabled\n"));
-          return EFI_INVALID_PARAMETER;
+          return EFI_UNSUPPORTED;
         }
 
         Reg32 = MmioRead32 ((UINTN)Drhd->RegisterBaseAddress + R_GSTS_REG);
         if ((Reg32 & B_GSTS_REG_TE) == 0) {
           DEBUG ((DEBUG_ERROR, "DMA remapping is not enabled\n"));
-          return EFI_INVALID_PARAMETER;
+          return EFI_UNSUPPORTED;
         }
 
         DEBUG ((DEBUG_INFO, "DMA remapping is enabled with Abort DMA Mode\n"));
       } else {
-        Reg32 = MmioRead32 ((UINTN)Drhd->RegisterBaseAddress + R_GSTS_REG);
-
         CapReg.Uint64 = MmioRead64 ((UINTN)Drhd->RegisterBaseAddress + R_CAP_REG);
         if (CapReg.Bits.PLMR == 0 || CapReg.Bits.PHMR == 0) {
-          return EFI_INVALID_PARAMETER;
+          return EFI_UNSUPPORTED;
         }
 
         Reg32 = MmioRead32 ((UINTN)Drhd->RegisterBaseAddress + R_PMEN_ENABLE_REG);
         if ((Reg32 & BIT0) == 0) {
-          return EFI_INVALID_PARAMETER;
+          return EFI_UNSUPPORTED;
         }
       }
 


### PR DESCRIPTION
## Description

According to the Intel® Virtualization Technology for Directed I/O specification, `PMEN_REG` is deprecated on newer platforms and is therefore not applicable for pre-boot DMA protection verification. **Abort DMA mode** supersedes `PMEN_REG`. This change introduces pre-boot DMA protection verification based on Abort DMA mode.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical Intel hardware with Abort DMA mode capability, the `TestPointMemoryDiscoveredDmaProtectionEnabled` passed with the change.

## Integration Instructions

N.A.