### PR TITLE
[Cherry-Pick] MinPlatformPkg/TestPointLib: Prevent calling FreePool on a NULL pointer

### DIFF
--- a/MinPlatformPkg/Test/Library/TestPointLib/DxeTestPoint.c
+++ b/MinPlatformPkg/Test/Library/TestPointLib/DxeTestPoint.c
@@ -72,11 +72,13 @@ InternalTestPointFindAip (
     //
     // Check AIP
     //
-    Status = Aip->GetSupportedTypes (
-                    Aip,
-                    &InfoTypesBuffer,
-                    &InfoTypesBufferCount
-                    );
+    InfoTypesBuffer      = NULL;
+    InfoTypesBufferCount = 0;
+    Status               = Aip->GetSupportedTypes (
+                                  Aip,
+                                  &InfoTypesBuffer,
+                                  &InfoTypesBufferCount
+                                  );
     if (EFI_ERROR (Status)) {
       continue;
     }
@@ -89,7 +91,9 @@ InternalTestPointFindAip (
       }
     }
 
-    FreePool (InfoTypesBuffer);
+    if (InfoTypesBuffer != NULL) {
+      FreePool (InfoTypesBuffer);
+    }
 
     if (AipCandidate == NULL) {
       continue;


### PR DESCRIPTION
## Description

Aip->GetSupportedTypes may return EFI_SUCCESS when 0 supported types are found. This results in an attempt to call FreePool on a NULL pointer. To fix this explicitly verify that InfoTypesBuffer is not NULL before attempting a FreePool on the pointer. If InfoTypesBuffer is NULL, then in most scenarios AipCandidate will remain NULL and the loop will hit the `AipCandidate == NULL` path.

Upstream commit: [MinPlatformPkg/TestPointLib: Prevent calling FreePool on a NULL pointer](https://github.com/tianocore/edk2-platforms/commit/ced51bd4cda50b1965807d77400798a22a22d80e)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Validated on ARM based Surface devices. The NULL pointer dereference no longer causes an exception as part of running the TestPoint code.

## Integration Instructions

N/A
