### PR TITLE
MinPlatformPkg: Align variable runtime DSC condition

### DIFF
--- a/MinPlatformPkg/Include/Dsc/CoreDxeInclude.dsc
+++ b/MinPlatformPkg/Include/Dsc/CoreDxeInclude.dsc
@@ -32,10 +32,12 @@
   #
   # Emulated variables for stages 1-4
   #
-  MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf {
-    <PcdsFixedAtBuild>
-      gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable|TRUE
-  }
+  !if gMinPlatformPkgTokenSpaceGuid.PcdBootToShellOnly == TRUE
+    MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf {
+      <PcdsFixedAtBuild>
+        gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable|TRUE
+    }
+  !endif
 
   #
   # Real variables for stages 5+


### PR DESCRIPTION
## Description

Guard `VariableRuntimeDxe.inf` in `CoreDxeInclude.dsc` with `gMinPlatformPkgTokenSpaceGuid.PcdBootToShellOnly == TRUE`, matching the existing condition in `CoreUefiBootInclude.fdf`.

This keeps the DSC component list aligned with the modules included in the firmware volume when `PcdBootToShellOnly` is disabled. This change mirrors tianocore/edk2-platforms#1046.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Confirmed that the DSC and FDF place `VariableRuntimeDxe.inf` under the same PCD condition, and checked the patch for whitespace errors using CRLF-aware Git settings.

## Integration Instructions

N/A